### PR TITLE
Improve First Stable mode to use proper stability detection

### DIFF
--- a/vsg_core/orchestrator/steps/analysis_step.py
+++ b/vsg_core/orchestrator/steps/analysis_step.py
@@ -69,8 +69,16 @@ def _choose_final_delay(results: List[Dict[str, Any]], config: Dict, runner: Com
     delays = [r['delay'] for r in accepted]
 
     if delay_mode == 'First Stable':
-        winner = delays[0]
-        method_label = "first stable"
+        # Use proper stability detection to find first stable segment
+        winner = _find_first_stable_segment_delay(results, runner)
+        if winner is None:
+            # Fallback to mode if no stable segment found
+            runner._log_message(f"[WARNING] No stable segment found, falling back to mode.")
+            counts = Counter(delays)
+            winner = counts.most_common(1)[0][0]
+            method_label = "mode (fallback)"
+        else:
+            method_label = "first stable"
     elif delay_mode == 'Average':
         winner = round(sum(delays) / len(delays))
         method_label = "average"


### PR DESCRIPTION
Changed "First Stable" delay selection mode to use the existing _find_first_stable_segment_delay() function instead of blindly taking the first chunk's delay.

Benefits:
- Groups consecutive chunks with same delay (±1ms tolerance)
- Returns delay from first STABLE segment (multiple agreeing chunks)
- More robust against outliers in early chunks
- Logs helpful info about segment size and start time
- Falls back to mode if no stable segment found

For user's example (chunks 1-4 @ -998ms, 5-12 @ -956ms, 13-30 @ -914ms):
- Old behavior: Would use -998ms (first chunk)
- New behavior: Uses -998ms (first stable segment of 4 chunks)
- Result is same, but now validated as stable

This makes "First Stable" more reliable for files with stepping/mastering issues where sync changes at discrete points.