### PR TITLE
Fix Tesseract tessdata path detection

### DIFF
--- a/vsg_core/subtitles/ocr_vobsub.py
+++ b/vsg_core/subtitles/ocr_vobsub.py
@@ -77,8 +77,22 @@ def run_vobsub_ocr(
 
         try:
             ocr_engine = TesseractEngine(ocr_config)
+
+            # Log tessdata path being used
+            if hasattr(ocr_engine, 'tessdata_path') and ocr_engine.tessdata_path:
+                runner._log_message(f"[OCR] Using tessdata path: {ocr_engine.tessdata_path}")
+            else:
+                runner._log_message("[OCR] Using tesserocr auto-detected tessdata path")
+
+            # Log OCR settings
+            runner._log_message(f"[OCR] Settings: PSM={ocr_engine.psm}, OEM={ocr_engine.oem}, Lang={ocr_engine.lang}")
+
         except ImportError as e:
             runner._log_message(f"[OCR] ERROR: {str(e)}")
+            return None
+        except Exception as e:
+            runner._log_message(f"[OCR] ERROR: Failed to initialize Tesseract: {str(e)}")
+            runner._log_message("[OCR] Make sure Tesseract OCR and language data are installed.")
             return None
 
         # Step 3: Initialize ASS builder


### PR DESCRIPTION
Added automatic tessdata path detection to fix "invalid tessdata path" errors:

Detection methods (in order):
1. Check TESSDATA_PREFIX environment variable
2. Query tesseract --print-parameters for path
3. Check common installation paths (/usr/share/tessdata, etc.)
4. Fall back to tesserocr auto-detection

Also added better logging:
- Shows which tessdata path is being used
- Logs OCR settings (PSM, OEM, language)
- Better error messages when Tesseract fails to initialize

This should resolve the tessdata path errors and make OCR work with standard Tesseract installations.