### PR TITLE
Fix pysubs2 Alignment enum attribute names

### DIFF
--- a/vsg_core/subtitles/builders/ass.py
+++ b/vsg_core/subtitles/builders/ass.py
@@ -144,13 +144,14 @@ class ASSBuilder:
         alignment_num = 1 + h_align + (v_align * 3)
 
         # Convert to pysubs2 Alignment enum
+        # Note: pysubs2 uses LEFT/CENTER/RIGHT for middle row, not CENTER_LEFT/etc
         alignment_map = {
             1: Alignment.BOTTOM_LEFT,
             2: Alignment.BOTTOM_CENTER,
             3: Alignment.BOTTOM_RIGHT,
-            4: Alignment.CENTER_LEFT,
-            5: Alignment.CENTER,
-            6: Alignment.CENTER_RIGHT,
+            4: Alignment.LEFT,        # Middle left
+            5: Alignment.CENTER,      # Middle center
+            6: Alignment.RIGHT,       # Middle right
             7: Alignment.TOP_LEFT,
             8: Alignment.TOP_CENTER,
             9: Alignment.TOP_RIGHT,


### PR DESCRIPTION
Changed alignment mapping to use correct pysubs2 Alignment enum values:
- Alignment.LEFT (not CENTER_LEFT) for middle-left (4)
- Alignment.CENTER for middle-center (5)
- Alignment.RIGHT (not CENTER_RIGHT) for middle-right (6)

This fixes the AttributeError that was preventing OCR from creating ASS events.