### PR TITLE
Fix OCR gibberish and positioning issues

### DIFF
--- a/vsg_core/subtitles/builders/ass.py
+++ b/vsg_core/subtitles/builders/ass.py
@@ -89,18 +89,18 @@ class ASSBuilder:
 
         # Calculate position for \pos tag
         if preserve_position:
-            # Calculate center point of subtitle
-            pos_x = x + (width // 2)
-            pos_y = y + (height // 2)
+            # Use top-left corner directly (no offset needed)
+            # Alignment 7 = top left, so \pos() positions the top-left of the text
+            pos_x = x
+            pos_y = y
 
-            # Apply positioning tag
-            text_with_pos = f"{{\\pos({pos_x},{pos_y})}}{text}"
+            # Apply positioning with alignment 7 (top-left)
+            # This ensures \pos(x,y) places the text exactly where it was in the original
+            text_with_pos = f"{{\\an7\\pos({pos_x},{pos_y})}}{text}"
         else:
             text_with_pos = text
 
         # Create event
-        # Note: We use \pos tags for positioning, so alignment is less important
-        # but we set it to 2 (bottom center) as a reasonable default
         event = SSAEvent(
             start=start_ms,
             end=end_ms,


### PR DESCRIPTION
Two critical fixes for the VobSub OCR system:

1. PREPROCESSING FIX (image.py):
   - Completely rewrote _invert_colors() with simple alpha-based approach
   - Previous approach tried to filter by alpha threshold and brightness, but VobSub uses a 4-color palette system where filtering doesn't work
   - New approach: Use alpha channel directly as grayscale data and invert
   - Alpha 255 (text) → 0 (black), Alpha 0 (background) → 255 (white)
   - Much simpler and should eliminate gibberish from borders/outlines

2. POSITIONING FIX (ass.py):
   - Fixed misaligned subtitles appearing in middle of screen
   - Root cause: Calculated center point but didn't set alignment, so ASS used default alignment causing misalignment
   - Solution: Use \an7 (top-left alignment) with x,y directly
   - Now \pos(x,y) places text exactly where it was in original VobSub

Changes:
- preprocessing/image.py: Simplified to alpha-only inversion (28 lines → 16 lines)
- builders/ass.py: Added \an7 alignment tag and removed center offset calculation

This should fix both the gibberish OCR output and the incorrect positioning.