### PR TITLE
Simplify preprocessing and add debug output

### DIFF
--- a/vsg_core/config.py
+++ b/vsg_core/config.py
@@ -17,7 +17,7 @@ class AppConfig:
 
             # --- OCR Settings (New Native Implementation) ---
             'ocr_engine': 'tesseract',
-            'ocr_tesseract_psm': 7,                # Page segmentation mode (7 = single text line)
+            'ocr_tesseract_psm': 6,                # Page segmentation mode (6 = uniform block of text)
             'ocr_tesseract_oem': 1,                # OCR engine mode (1 = LSTM neural net)
             'ocr_preprocessing_scale': True,        # Enable image upscaling
             'ocr_preprocessing_denoise': False,     # Enable denoising

--- a/vsg_core/subtitles/ocr_vobsub.py
+++ b/vsg_core/subtitles/ocr_vobsub.py
@@ -73,7 +73,10 @@ def run_vobsub_ocr(
         ocr_config = config.copy()
         ocr_config['ocr_lang'] = lang
 
-        preprocessor = ImagePreprocessor(ocr_config)
+        # Enable debug output
+        debug_dir = idx_file.parent / 'ocr_debug'
+        preprocessor = ImagePreprocessor(ocr_config, debug_dir=str(debug_dir))
+        runner._log_message(f"[OCR] Debug images will be saved to: {debug_dir}")
 
         try:
             ocr_engine = TesseractEngine(ocr_config)


### PR DESCRIPTION
Major changes to fix gibberish OCR:

1. SIMPLIFIED PREPROCESSING (image.py):
   - Removed complex luminance + alpha filtering (was too aggressive)
   - Now using simple PIL RGBA composite onto white background
   - Convert to grayscale using PIL's built-in conversion
   - Disabled binarization - let Tesseract handle it internally
   - Disabled line segmentation - using PSM 6 instead
   - Added debug image saving to troubleshoot issues

2. CHANGED PSM MODE (config.py):
   - Changed from PSM 7 (single line) to PSM 6 (uniform block)
   - PSM 6 better handles multi-line subtitles
   - Matches what subtile-ocr uses

3. ENABLED DEBUG OUTPUT (ocr_vobsub.py):
   - Preprocessed images now saved to ocr_debug/ directory
   - Allows visual inspection of what Tesseract receives

The previous approach was filtering too aggressively based on luminance and alpha thresholds, likely removing actual text. This simpler approach lets Tesseract's internal preprocessing do the work.

Debug images will show exactly what's being OCRed so we can diagnose why gibberish is still appearing.