### PR TITLE
Fix positioning and OCR quality - implement subtile-ocr approach

### DIFF
--- a/vsg_core/config.py
+++ b/vsg_core/config.py
@@ -17,7 +17,7 @@ class AppConfig:
 
             # --- OCR Settings (New Native Implementation) ---
             'ocr_engine': 'tesseract',
-            'ocr_tesseract_psm': 6,                # Page segmentation mode (6 = uniform block of text)
+            'ocr_tesseract_psm': 7,                # Page segmentation mode (7 = single line, best with line segmentation)
             'ocr_tesseract_oem': 1,                # OCR engine mode (1 = LSTM neural net)
             'ocr_preprocessing_scale': True,        # Enable image upscaling
             'ocr_preprocessing_denoise': False,     # Enable denoising


### PR DESCRIPTION
This fixes two critical issues:
1. All subtitles positioned at (0,2) instead of correct coordinates
2. Poor OCR quality with missing/incorrect letters

ROOT CAUSES:

1. POSITIONING BUG - Incorrect display area parsing (command 0x05)
   - The 6-byte display area was parsed incorrectly
   - All subtitles ended up at x=0, y=2 (top-left corner)
   - Based on VobSub-ML-OCR, the format is 4 x 12-bit coordinates packed into 6 bytes

2. OCR QUALITY - Wrong text color for Tesseract
   - Tesseract 4.0+ expects BLACK text on WHITE background
   - VobSub subtitles have WHITE text on dark/transparent background
   - Without inversion, OCR quality is poor

CHANGES TO PARSERS/VOBSUB.PY:

Fixed _parse_control_sequence() command 0x05 parsing:
- Correctly extract 4 x 12-bit coordinates from 6 bytes
- starting_x = (bytes 0-1) >> 4
- ending_x = (byte 1 lower 4 bits << 8) | byte 2
- starting_y = (bytes 3-4) >> 4
- ending_y = (byte 4 lower 4 bits << 8) | byte 5
- Matches VobSub-ML-OCR implementation exactly

This fixes positioning - subtitles now appear at their original coordinates.

CHANGES TO PREPROCESSING/IMAGE.PY:

Implemented subtile-ocr approach for better OCR quality:

1. Background normalization (_normalize_background):
   - Detect if text is bright (avg brightness > 127)
   - If bright text: invert image (white->black, dark->white)
   - Tesseract now gets BLACK text on WHITE background
   - This is the KEY improvement from subtile-ocr

2. Line segmentation (_segment_lines):
   - Split multi-line subtitles into separate images
   - Each line processed independently with PSM 7
   - Greatly improves accuracy for non-English languages
   - Matches subtile-ocr approach

3. Enhanced debug output:
   - raw_extracted_{n}.png: Original from parser
   - preprocessed_{n}_line{i}.png: Each segmented line
   - Allows visual inspection of preprocessing

CHANGES TO CONFIG.PY:

Changed PSM mode from 6 to 7:
- PSM 6: Uniform block of text (for multi-line)
- PSM 7: Single line (for segmented lines)
- With line segmentation, PSM 7 gives better accuracy
- Matches subtile-ocr configuration

TECHNICAL DETAILS:

Display Area Format (DVD SPU command 0x05):
- 6 bytes contain 4 coordinates (X1, X2, Y1, Y2)
- Each coordinate is 12 bits (0-4095 range)
- Packed as: XXXX XXXX XXXX YYYY YYYY YYYY (in nibbles)
- Previous code had complex/incorrect bit shifting

Background Normalization:
- VobSub: typically white/yellow text on black/transparent bg
- Tesseract 4.0: expects black text on white background
- Solution: detect brightness and invert if needed
- Critical for good OCR accuracy

Line Segmentation + PSM 7:
- Multi-line subtitles confuse Tesseract (especially non-English)
- Split into separate lines using row histogram
- Process each line with PSM 7 (single line mode)
- Significantly better accuracy than PSM 6 on full image

BASED ON:
- VobSub-ML-OCR: Display area parsing
- subtile-ocr: Background normalization and line segmentation

Subtitles should now:
- Appear at correct positions (not all at top-left)
- Have much better OCR accuracy
- Handle multi-line subtitles properly