### PR TITLE
Strip all preprocessing to match VobSub-ML-OCR (minimal approach)

### DIFF
--- a/vsg_core/config.py
+++ b/vsg_core/config.py
@@ -17,7 +17,7 @@ class AppConfig:
 
             # --- OCR Settings (New Native Implementation) ---
             'ocr_engine': 'tesseract',
-            'ocr_tesseract_psm': 7,                # Page segmentation mode (7 = single line, works with line segmentation)
+            'ocr_tesseract_psm': 3,                # Page segmentation mode (3 = fully automatic, best for unknown layout)
             'ocr_tesseract_oem': 1,                # OCR engine mode (1 = LSTM neural net)
             'ocr_preprocessing_scale': True,        # Enable image upscaling
             'ocr_preprocessing_denoise': False,     # Enable denoising


### PR DESCRIPTION
CRITICAL REALIZATION:
VobSub-ML-OCR does ZERO preprocessing and gets better results than our 81% success rate. We were doing too much: inversion, segmentation, borders.

ROOT CAUSE ANALYSIS:

1. VobSub-ML-OCR: NO preprocessing → better results
2. Our approach: LOTS of preprocessing → 81% success (19% failure)
3. Conclusion: Preprocessing is HURTING, not helping

CHANGES:

1. REMOVED inversion (_normalize_background)
   - Our images from parser should already be correct
   - Inversion was likely breaking some images

2. REMOVED line segmentation (_segment_lines)
   - Was cutting off text in some cases
   - Tesseract can handle multi-line with PSM 3

3. REMOVED border padding (_add_border)
   - Not needed if images are already correct

4. KEPT scaling only
   - Tesseract does like larger text
   - This is safe and helpful

5. Changed PSM: 7 → 3
   - PSM 7: Single line (requires segmentation)
   - PSM 3: Fully automatic (best for unknown layout)
   - Matches what Tesseract recommends

NEW PIPELINE:
Raw image → RGB conversion → Scale (optional) → OCR with PSM 3

This matches VobSub-ML-OCR philosophy: trust the image generation, let the OCR engine do its job without interference.