### PR TITLE
Change default fill mode to silence and decouple stepping scan ranges

### DIFF
--- a/vsg_core/config.py
+++ b/vsg_core/config.py
@@ -116,10 +116,12 @@ class AppConfig:
 
             # --- Stepping Correction Enhancements ---
             'stepping_min_cluster_size': 3,  # Minimum chunks per cluster to qualify as stepping
-            'stepping_fill_mode': 'auto',  # 'auto', 'silence', or 'content' - how to fill delay gaps
+            'stepping_fill_mode': 'silence',  # 'auto', 'silence', or 'content' - how to fill delay gaps
             'stepping_diagnostics_verbose': True,  # Enable detailed cluster composition reports
-            'stepping_content_correlation_threshold': 0.5,  # Min correlation for content extraction
-            'stepping_content_search_window_s': 5.0,  # Search window for finding matching content
+            'stepping_content_correlation_threshold': 0.5,  # Min correlation for content extraction (for auto/content modes)
+            'stepping_content_search_window_s': 5.0,  # Search window for finding matching content (for auto/content modes)
+            'stepping_scan_start_percentage': 5.0,  # Independent scan start for stepping correction
+            'stepping_scan_end_percentage': 99.0,  # Independent scan end for stepping correction (higher to catch end boundaries)
         }
         self.settings = self.defaults.copy()
         self.load()

--- a/vsg_core/correction/stepping.py
+++ b/vsg_core/correction/stepping.py
@@ -118,8 +118,10 @@ class SteppingCorrector:
         coarse_map = []
         num_samples = min(len(ref_pcm), len(analysis_pcm))
         duration_s = len(ref_pcm) / float(sample_rate)
-        start_pct = self.config.get('scan_start_percentage', 5.0)
-        end_pct = self.config.get('scan_end_percentage', 95.0)
+
+        # Use stepping-specific scan ranges (independent from main analysis settings)
+        start_pct = self.config.get('stepping_scan_start_percentage', 5.0)
+        end_pct = self.config.get('stepping_scan_end_percentage', 99.0)
         scan_start_s = duration_s * (start_pct / 100.0)
         scan_end_s = duration_s * (end_pct / 100.0)
         start_offset_samples = int(scan_start_s * sample_rate)

--- a/vsg_qt/options_dialog/tabs.py
+++ b/vsg_qt/options_dialog/tabs.py
@@ -284,12 +284,12 @@ class AnalysisTab(QWidget):
         )
 
         self.widgets['stepping_fill_mode'] = QComboBox()
-        self.widgets['stepping_fill_mode'].addItems(['auto', 'silence', 'content'])
+        self.widgets['stepping_fill_mode'].addItems(['silence', 'auto', 'content'])
         self.widgets['stepping_fill_mode'].setToolTip(
             "How to fill gaps when delay increases:\n"
-            "• auto: Intelligently decides between content and silence based on correlation analysis (Recommended)\n"
-            "• silence: Always insert pure silence (traditional behavior, safe)\n"
-            "• content: Always extract content from reference audio (use if Source 1 is complete)"
+            "• silence: Always insert pure silence (RECOMMENDED - safe and professional)\n"
+            "• auto: Intelligently decides between content and silence based on correlation analysis (experimental)\n"
+            "• content: Always extract content from reference audio (experimental, may cause audio artifacts)"
         )
 
         self.widgets['stepping_diagnostics_verbose'] = QCheckBox("Enable detailed cluster diagnostics")
@@ -319,11 +319,33 @@ class AnalysisTab(QWidget):
             "Default: 5.0 seconds is usually sufficient."
         )
 
+        self.widgets['stepping_scan_start_percentage'] = QDoubleSpinBox()
+        self.widgets['stepping_scan_start_percentage'].setRange(0.0, 99.0)
+        self.widgets['stepping_scan_start_percentage'].setSuffix(" %")
+        self.widgets['stepping_scan_start_percentage'].setDecimals(1)
+        self.widgets['stepping_scan_start_percentage'].setToolTip(
+            "Where to begin stepping correction coarse scan (independent from main analysis scan).\n"
+            "Usually same as main analysis start (5%), but can be adjusted separately.\n"
+            "Default: 5.0%"
+        )
+
+        self.widgets['stepping_scan_end_percentage'] = QDoubleSpinBox()
+        self.widgets['stepping_scan_end_percentage'].setRange(1.0, 100.0)
+        self.widgets['stepping_scan_end_percentage'].setSuffix(" %")
+        self.widgets['stepping_scan_end_percentage'].setDecimals(1)
+        self.widgets['stepping_scan_end_percentage'].setToolTip(
+            "Where to end stepping correction coarse scan (independent from main analysis scan).\n"
+            "Set higher than main analysis (e.g., 99%) to catch stepping at file end.\n"
+            "Default: 99.0%"
+        )
+
         segment_layout.addRow("Min. Cluster Size:", self.widgets['stepping_min_cluster_size'])
         segment_layout.addRow("Gap Fill Mode:", self.widgets['stepping_fill_mode'])
         segment_layout.addRow(self.widgets['stepping_diagnostics_verbose'])
         segment_layout.addRow("Content Correlation Threshold:", self.widgets['stepping_content_correlation_threshold'])
         segment_layout.addRow("Content Search Window:", self.widgets['stepping_content_search_window_s'])
+        segment_layout.addRow("Stepping Scan Start:", self.widgets['stepping_scan_start_percentage'])
+        segment_layout.addRow("Stepping Scan End:", self.widgets['stepping_scan_end_percentage'])
 
         main_layout.addWidget(segment_group)
 


### PR DESCRIPTION
Changes:
--------
1. Changed default stepping_fill_mode from 'auto' to 'silence'
   - Silence mode is safer and more professional
   - Avoids audio artifacts from experimental content extraction
   - Smart Fill (auto/content modes) remain available but experimental

2. Added independent scan range settings for stepping correction
   - New config: stepping_scan_start_percentage (default: 5.0%)
   - New config: stepping_scan_end_percentage (default: 99.0%)
   - Decoupled from main analysis scan_start/end_percentage settings
   - Allows stepping to scan 5-99% while main analysis stays at 5-95%

3. Updated UI controls
   - Reordered fill mode dropdown to show 'silence' first (default)
   - Updated tooltips to mark silence as RECOMMENDED
   - Added two new UI controls for stepping scan ranges
   - Labeled auto/content modes as "experimental"

Rationale:
----------
- Main analysis typically scans 5-95% to avoid intro/outro issues
- Stepping correction needs to scan closer to file end (99%) to catch final boundaries that occur in last few minutes (like end credits timing)
- Users can now configure these independently based on their needs

Professional Approach:
---------------------
Silence insertion is the standard professional method for handling reel changes, commercial breaks, or timing discontinuities. Content extraction is experimental and prone to artifacts when sources have different edits, takes, or timing.