### PR TITLE
Fix double-delay issue for stepping-adjusted subtitles

### DIFF
--- a/vsg_core/models/jobs.py
+++ b/vsg_core/models/jobs.py
@@ -37,6 +37,7 @@ class PlanItem:
     container_delay_ms: int = 0
     custom_lang: str = ''
     aspect_ratio: Optional[str] = None  # NEW: Store original aspect ratio (e.g., "109:60")
+    stepping_adjusted: bool = False  # True if subtitle timestamps were adjusted for stepping corrections
 
 @dataclass(frozen=True)
 class MergePlan:

--- a/vsg_core/mux/options_builder.py
+++ b/vsg_core/mux/options_builder.py
@@ -148,6 +148,14 @@ class MkvmergeOptionsBuilder:
         # - Audio/video from other sources (correlation delay + global shift)
         # - Subtitles from other sources (correlation delay + global shift)
         # - External subtitles (synced to a specific source)
+
+        # SPECIAL CASE: Subtitles with stepping-adjusted timestamps
+        # If subtitle timestamps were already adjusted for stepping corrections,
+        # the base delay + stepping offsets are baked into the subtitle file.
+        # Don't apply additional delay via mkvmerge to avoid double-applying.
+        if tr.type == TrackType.SUBTITLES and item.stepping_adjusted:
+            return 0
+
         sync_key = item.sync_to if tr.source == 'External' else tr.source
         delay = plan.delays.source_delays_ms.get(sync_key, 0)
         return int(delay)

--- a/vsg_core/orchestrator/steps/subtitles_step.py
+++ b/vsg_core/orchestrator/steps/subtitles_step.py
@@ -126,6 +126,8 @@ class SubtitlesStep:
                                 for key, value in stepping_report.items():
                                     runner._log_message(f"  - {key.replace('_', ' ').title()}: {value}")
                                 runner._log_message("--------------------------------")
+                                # Mark that timestamps have been adjusted (so mux doesn't double-apply delay)
+                                item.stepping_adjusted = True
 
                     if item.perform_ocr_cleanup:
                         report = run_cleanup(ocr_output_path, ctx.settings_dict, runner)
@@ -173,6 +175,8 @@ class SubtitlesStep:
                             for key, value in stepping_report.items():
                                 runner._log_message(f"  - {key.replace('_', ' ').title()}: {value}")
                             runner._log_message("--------------------------------")
+                            # Mark that timestamps have been adjusted (so mux doesn't double-apply delay)
+                            item.stepping_adjusted = True
 
             if item.convert_to_ass and item.extracted_path and item.extracted_path.suffix.lower() == '.srt':
                 new_path = convert_srt_to_ass(str(item.extracted_path), runner, ctx.tool_paths)


### PR DESCRIPTION
Critical fix: Subtitles from stepped sources were getting the base delay applied twice - once baked into the subtitle file via timestamp adjustment, and again via mkvmerge's --sync flag. This caused subtitles to be offset by the base delay amount (e.g., +516ms).

Solution:
- Added stepping_adjusted flag to PlanItem
- Set flag to True when subtitle timestamps are adjusted for stepping
- Modified mux delay calculation to return 0 for stepping-adjusted subtitles
- This prevents double-applying the base delay

Now subtitle timestamps correctly incorporate:
1. Base delay (e.g., +516ms) from first EDL segment
2. All stepping corrections (insertions/removals) And mkvmerge doesn't add an additional delay on top.

This ensures subtitles stay perfectly synchronized with stepped audio.