### PR TITLE
Fix PGS OCR: Remove forced .idx extension in subtitle processing

### DIFF
--- a/vsg_core/orchestrator/steps/subtitles_step.py
+++ b/vsg_core/orchestrator/steps/subtitles_step.py
@@ -40,7 +40,7 @@ class SubtitlesStep:
 
             if item.perform_ocr and item.extracted_path:
                 ocr_output_path = run_ocr(
-                    str(item.extracted_path.with_suffix('.idx')),
+                    str(item.extracted_path),
                     item.track.props.lang,
                     runner,
                     ctx.tool_paths,
@@ -150,7 +150,7 @@ class SubtitlesStep:
                     runner._log_message(
                         f"[OCR] ERROR: OCR tool failed for track {item.track.id} "
                         f"({item.track.props.name or 'Unnamed'}). "
-                        f"Check that subtile-ocr is installed and the IDX/SUB files are valid."
+                        f"Check that OCR tools (subtile-ocr or Tesseract) are installed and subtitle files are valid."
                     )
                     runner._log_message(
                         f"[OCR] WARNING: Keeping original image-based subtitle for track {item.track.id}."


### PR DESCRIPTION
CRITICAL BUG FIX: subtitles_step.py was forcing ALL image-based subtitles to use .idx extension, causing PGS (.sup) files to be incorrectly treated as VobSub files.

Changes:
- Line 43: Removed .with_suffix('.idx') call
- Now passes item.extracted_path directly to run_ocr()
- OCR system correctly detects format by actual file extension
- .sup files route to PGS OCR, .idx files route to VobSub OCR

Also updated error message to mention both OCR systems (subtile-ocr and Tesseract) instead of just VobSub-specific message.

This was preventing PGS OCR from working in real jobs even though the standalone implementation was correct.