### PR TITLE
Add comprehensive debugging for PGS OCR issues

### DIFF
--- a/vsg_core/subtitles/ocr.py
+++ b/vsg_core/subtitles/ocr.py
@@ -115,7 +115,8 @@ def run_pgs_ocr(
             from_matroska=False,
             tesseract_path=tesseract_path,
             preprocess_settings=preprocess_settings,
-            log_callback=runner._log_message
+            log_callback=runner._log_message,
+            save_debug_images=True  # Enable debug images for now
         )
 
         if result and Path(result).exists():

--- a/vsg_core/subtitles/pgs/__init__.py
+++ b/vsg_core/subtitles/pgs/__init__.py
@@ -132,7 +132,8 @@ def extract_pgs_subtitles(
     from_matroska: bool = False,
     tesseract_path: Optional[str] = None,
     preprocess_settings: Optional[PreprocessSettings] = None,
-    log_callback=None
+    log_callback=None,
+    save_debug_images: bool = False
 ) -> Optional[str]:
     """
     Extract and OCR PGS subtitles from .sup file.
@@ -225,6 +226,17 @@ def extract_pgs_subtitles(
 
                 # Preprocess for OCR
                 processed = preprocess_for_ocr(image, preprocess_settings)
+
+                # Save debug images if requested
+                if save_debug_images:
+                    debug_dir = Path(sup_path).parent / "pgs_debug"
+                    debug_dir.mkdir(exist_ok=True)
+                    try:
+                        image.save(debug_dir / f"sub_{i+1:04d}_original.png")
+                        processed.save(debug_dir / f"sub_{i+1:04d}_processed.png")
+                        log(f"[PGS OCR] Debug images saved to {debug_dir}")
+                    except Exception as e:
+                        log(f"[PGS OCR] Warning: Could not save debug images: {e}")
 
                 # Run OCR
                 text = run_ocr_with_postprocessing(


### PR DESCRIPTION
Improve error reporting and add debug image saving to diagnose OCR failures:

Tesseract error handling (ocr_tesseract.py):
- Fix empty string tesseract_path not triggering auto-detection
- Check subprocess return code and log detailed error messages
- Log command, stdout, stderr when tesseract fails
- Report when hOCR file is not created
- Better exception handling with full tracebacks

Debug image saving (__init__.py):
- Add save_debug_images parameter to extract_pgs_subtitles()
- Save both original and preprocessed images when enabled
- Images saved to pgs_debug/ folder in temp directory
- Helps diagnose preprocessing issues

Temporary debugging (ocr.py):
- Enable save_debug_images=True by default for testing
- Will help identify why OCR is failing to extract text

Next step: Run job and check:
1. Terminal output for [Tesseract] ERROR messages
2. pgs_debug/ folder for before/after images
3. Whether images are readable after preprocessing