### PR TITLE
Fix preprocessing for outlined PGS text - use black background

### DIFF
--- a/vsg_core/config.py
+++ b/vsg_core/config.py
@@ -26,10 +26,10 @@ class AppConfig:
             'pgs_add_margin': 10,
             'pgs_invert_colors': False,
             'pgs_yellow_to_white': True,
-            'pgs_binarize': True,
+            'pgs_binarize': False,  # Disabled - causes issues with outlined text
             'pgs_binarize_threshold': 200,
             'pgs_scale_percent': 100,
-            'pgs_enhance_contrast': 1.5,
+            'pgs_enhance_contrast': 1.0,  # Disabled - let Tesseract handle it
 
             'ocr_cleanup_enabled': True,
             'ocr_cleanup_normalize_ellipsis': False,

--- a/vsg_core/subtitles/pgs/preprocessor.py
+++ b/vsg_core/subtitles/pgs/preprocessor.py
@@ -219,6 +219,7 @@ def preprocess_for_ocr(img: Image.Image, settings: PreprocessSettings) -> Image.
     Apply complete preprocessing pipeline for OCR optimization.
 
     Processing order (important!):
+    0. Convert transparent background to white (Tesseract doesn't handle transparency)
     1. Color replacements (yellow -> white)
     2. Contrast enhancement
     3. Add margin
@@ -233,6 +234,17 @@ def preprocess_for_ocr(img: Image.Image, settings: PreprocessSettings) -> Image.
     Returns:
         Preprocessed image ready for OCR
     """
+    # Step 0: Convert transparent background to black
+    # Tesseract doesn't handle RGBA well, needs solid background
+    # Use BLACK background so white text with black outline is visible
+    # (white on white would be invisible!)
+    if img.mode == 'RGBA':
+        # Create black background
+        background = Image.new('RGB', img.size, (0, 0, 0))
+        # Paste image on black background using alpha channel as mask
+        background.paste(img, mask=img.split()[3])
+        img = background
+
     # Step 1: Color replacements
     if settings.yellow_to_white:
         img = replace_yellow_with_white(img)


### PR DESCRIPTION
CRITICAL FIX: PGS subtitles with outlined text were being preprocessed incorrectly, making them unreadable by Tesseract.

Problem:
- PGS subtitles often have white text core + black outline on transparent
- Binarization was treating outline as foreground, creating hollow letters
- White background made white text invisible (white on white)
- Result: "bubble letters" that Tesseract couldn't read

Solution:

1. Disabled aggressive preprocessing by default (config.py):
   - pgs_binarize: False (was causing hollow letter effect)
   - pgs_enhance_contrast: 1.0 (let Tesseract handle it)

2. Convert transparent to BLACK background (preprocessor.py):
   - PGS: White text + black outline + transparent background
   - After: White text + black outline + BLACK background
   - Result: Readable white-on-black text for Tesseract

3. Process transparent background FIRST:
   - Added Step 0 before all other preprocessing
   - Ensures Tesseract gets clean RGB image (not RGBA)
   - Preserves text visibility with proper contrast

Tesseract should now be able to read PGS subtitles with standard white text + black outline style.