### PR TITLE
Fix Tesseract OCR to use plain text output and try multiple PSM modes

### DIFF
--- a/vsg_core/subtitles/pgs/__init__.py
+++ b/vsg_core/subtitles/pgs/__init__.py
@@ -238,13 +238,34 @@ def extract_pgs_subtitles(
                     except Exception as e:
                         log(f"[PGS OCR] Warning: Could not save debug images: {e}")
 
-                # Run OCR
+                # Run OCR - Try multiple PSM modes if first fails
+                text = ""
+
+                # Try PSM 7 first (single text line - best for subtitles)
                 text = run_ocr_with_postprocessing(
                     processed,
                     lang=lang,
-                    psm=6,  # Uniform block of text (best for subtitles)
+                    psm=7,  # Single text line
                     tesseract_path=tesseract_path
                 )
+
+                # If PSM 7 failed, try PSM 6 (uniform block)
+                if not text.strip():
+                    text = run_ocr_with_postprocessing(
+                        processed,
+                        lang=lang,
+                        psm=6,  # Uniform block
+                        tesseract_path=tesseract_path
+                    )
+
+                # If still no text, try PSM 3 (fully automatic)
+                if not text.strip():
+                    text = run_ocr_with_postprocessing(
+                        processed,
+                        lang=lang,
+                        psm=3,  # Fully automatic
+                        tesseract_path=tesseract_path
+                    )
 
                 if not text.strip():
                     log(f"[PGS OCR] Warning: No text extracted from subtitle {i+1}")

--- a/vsg_core/subtitles/pgs/ocr_tesseract.py
+++ b/vsg_core/subtitles/pgs/ocr_tesseract.py
@@ -98,6 +98,7 @@ def run_tesseract_ocr(
         output_base = tempfile.mktemp()
 
         # Build command
+        # Try plain text output first (simpler, more reliable)
         cmd = [
             tesseract_path,
             input_file,
@@ -105,7 +106,7 @@ def run_tesseract_ocr(
             '-l', lang,
             '--psm', str(psm),
             '--oem', str(oem),
-            'hocr'  # Output in hOCR format (HTML with positioning)
+            # Note: no output format means stdout/txt file
         ]
 
         # Add additional config if provided
@@ -128,25 +129,22 @@ def run_tesseract_ocr(
             print(f"[Tesseract] Error output: {error_msg}")
             return ""
 
-        # Read hOCR output
-        hocr_file = output_base + '.hocr'
-        if os.path.exists(hocr_file):
-            with open(hocr_file, 'r', encoding='utf-8') as f:
-                hocr_content = f.read()
-
-            # Parse hOCR to extract text
-            text = parse_hocr(hocr_content)
+        # Read plain text output
+        txt_file = output_base + '.txt'
+        if os.path.exists(txt_file):
+            with open(txt_file, 'r', encoding='utf-8') as f:
+                text = f.read().strip()
 
             # Clean up output file
             try:
-                os.unlink(hocr_file)
+                os.unlink(txt_file)
             except:
                 pass
 
             return text
         else:
-            # hOCR file not created, possibly error
-            print(f"[Tesseract] ERROR: hOCR file not created at {hocr_file}")
+            # Output file not created, possibly error
+            print(f"[Tesseract] ERROR: Output file not created at {txt_file}")
             print(f"[Tesseract] Stdout: {result.stdout}")
             print(f"[Tesseract] Stderr: {result.stderr}")
             return ""


### PR DESCRIPTION
Changes:
- Switch from hOCR to plain text output for simpler, more reliable OCR
- Try PSM 7 (single line) first, then PSM 6 (block), then PSM 3 (auto)
- Fix output file reading to use .txt instead of .hocr
- PSM 7 is more appropriate for subtitle text (single lines)

This should resolve the issue where Tesseract returns no text despite correct image extraction and preprocessing.