### PR TITLE
Improve PGS OCR: auto-calculate font size and enhance Tesseract accuracy

### DIFF
--- a/vsg_core/config.py
+++ b/vsg_core/config.py
@@ -30,6 +30,7 @@ class AppConfig:
             'pgs_binarize_threshold': 200,
             'pgs_scale_percent': 100,
             'pgs_enhance_contrast': 1.0,  # Disabled - let Tesseract handle it
+            'pgs_font_size': 0,  # 0 = auto-calculate from image height, otherwise use specified size
 
             'ocr_cleanup_enabled': True,
             'ocr_cleanup_normalize_ellipsis': False,

--- a/vsg_core/subtitles/ocr.py
+++ b/vsg_core/subtitles/ocr.py
@@ -92,6 +92,10 @@ def run_pgs_ocr(
         # Get tesseract path from config if specified
         tesseract_path = config.get('tesseract_path')
 
+        # Get font size from config (0 = auto-calculate)
+        font_size_config = config.get('pgs_font_size', 0)
+        font_size = None if font_size_config == 0 else font_size_config
+
         # Create preprocessing settings from config
         preprocess_settings = PreprocessSettings(
             crop_transparent=config.get('pgs_crop_transparent', True),
@@ -115,6 +119,7 @@ def run_pgs_ocr(
             from_matroska=False,
             tesseract_path=tesseract_path,
             preprocess_settings=preprocess_settings,
+            font_size=font_size,
             log_callback=runner._log_message,
             save_debug_images=True  # Enable debug images for now
         )

--- a/vsg_core/subtitles/pgs/ocr_tesseract.py
+++ b/vsg_core/subtitles/pgs/ocr_tesseract.py
@@ -255,7 +255,8 @@ def run_ocr_with_postprocessing(
     image: Image.Image,
     lang: str = 'eng',
     psm: int = 6,
-    tesseract_path: Optional[str] = None
+    tesseract_path: Optional[str] = None,
+    config: Optional[str] = None
 ) -> str:
     """
     Run OCR with automatic post-processing.
@@ -265,9 +266,10 @@ def run_ocr_with_postprocessing(
         lang: Language code
         psm: Page segmentation mode
         tesseract_path: Path to tesseract executable
+        config: Additional Tesseract config options
 
     Returns:
         Cleaned OCR text
     """
-    raw_text = run_tesseract_ocr(image, lang, psm, tesseract_path=tesseract_path)
+    raw_text = run_tesseract_ocr(image, lang, psm, tesseract_path=tesseract_path, config=config)
     return postprocess_text(raw_text)

--- a/vsg_qt/options_dialog/tabs.py
+++ b/vsg_qt/options_dialog/tabs.py
@@ -125,6 +125,13 @@ class StorageTab(QWidget):
         self.widgets['pgs_enhance_contrast'].setToolTip("Contrast enhancement factor (1.0 = no change, 1.5 = default)")
         pgs_layout.addRow('Contrast Enhancement:', self.widgets['pgs_enhance_contrast'])
 
+        self.widgets['pgs_font_size'] = QSpinBox()
+        self.widgets['pgs_font_size'].setRange(0, 120)
+        self.widgets['pgs_font_size'].setValue(0)
+        self.widgets['pgs_font_size'].setSpecialValueText("Auto")
+        self.widgets['pgs_font_size'].setToolTip("Font size in ASS output (0 = auto-calculate from image height, typical: 30-60 for 1080p)")
+        pgs_layout.addRow('Font Size:', self.widgets['pgs_font_size'])
+
         self.widgets['pgs_add_margin'] = QSpinBox()
         self.widgets['pgs_add_margin'].setRange(0, 50)
         self.widgets['pgs_add_margin'].setValue(10)


### PR DESCRIPTION
Font Size Improvements:
- Auto-calculate font size from median image height (with 1.2x scaling)
- Bounds: minimum 30pt, maximum 80pt (suitable for various resolutions)
- Add configurable font size override option (0 = auto)
- Update ASS generation to use calculated/configured font size
- Default auto-calculated sizes work well for 1080p (typically 40-60pt)

Tesseract OCR Enhancements:
- Add preserve_interword_spaces=1 config for better word spacing
- Pass config through run_ocr_with_postprocessing
- Apply config to all PSM modes (7, 6, 3)

UI Updates:
- Add "Font Size" spinbox in PGS OCR settings
- Range: 0-120 (0 shows as "Auto" and triggers auto-calculation)
- Tooltip explains auto-calculation and typical values

Config Changes:
- Add pgs_font_size config option (default: 0 = auto)
- Pass font_size from config to extract_pgs_subtitles

This fixes the issue where text appeared super small in ASS output. Font size 20 was too small for 1080p - now auto-calculated based on actual subtitle image heights for proper visual matching.