### PR TITLE
Add folder-based subtitle matching feature

### DIFF
--- a/vsg_core/job_discovery.py
+++ b/vsg_core/job_discovery.py
@@ -2,15 +2,43 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 from pathlib import Path
-from typing import List, Dict
+from typing import List, Dict, Optional
 
-def discover_jobs(sources: Dict[str, str]) -> List[Dict[str, Dict[str, str]]]:
+
+def _find_matching_subtitle_folder(video_file_path: Path, subtitle_base_path: Path) -> Optional[Path]:
+    """
+    Find a subtitle folder matching the video file name.
+    Matches folder name to video file stem (filename without extension).
+
+    Args:
+        video_file_path: Path to the video file
+        subtitle_base_path: Base path containing subtitle subfolders
+
+    Returns:
+        Path to matching subtitle folder if found, None otherwise
+    """
+    video_stem = video_file_path.stem  # filename without extension
+    potential_folder = subtitle_base_path / video_stem
+
+    if potential_folder.exists() and potential_folder.is_dir():
+        return potential_folder
+
+    return None
+
+
+def discover_jobs(sources: Dict[str, str], subtitle_folder_path: str = None, subtitle_folder_sync_source: str = "Source 1") -> List[Dict[str, Dict[str, str]]]:
     """
     Discovers jobs based on a dictionary of source paths.
     'Source 1' is the reference for filename matching.
     Returns a list of job dictionaries, each with a 'sources' key.
 
     NEW: Supports single-source (Source 1 only) for remux-only mode.
+    NEW: Supports subtitle folder matching - matches folder names to video file stems.
+
+    Args:
+        sources: Dict of source paths ("Source 1", "Source 2", etc.)
+        subtitle_folder_path: Optional path to folder containing subtitle subfolders
+        subtitle_folder_sync_source: Which source to sync subtitle delays to (default "Source 1")
     """
     source1_path_str = sources.get("Source 1")
     if not source1_path_str:
@@ -22,6 +50,15 @@ def discover_jobs(sources: Dict[str, str]) -> List[Dict[str, Dict[str, str]]]:
 
     other_source_paths = {key: Path(path) for key, path in sources.items() if key != "Source 1" and path}
 
+    # Parse subtitle folder path if provided
+    subtitle_base_path = None
+    if subtitle_folder_path:
+        subtitle_base_path = Path(subtitle_folder_path)
+        if not subtitle_base_path.exists():
+            raise FileNotFoundError(f"Subtitle folder path does not exist: {subtitle_base_path}")
+        if not subtitle_base_path.is_dir():
+            raise ValueError(f"Subtitle folder path must be a directory: {subtitle_base_path}")
+
     # --- Single File Mode ---
     if source1_path.is_file():
         job_sources = {"Source 1": str(source1_path)}
@@ -31,9 +68,17 @@ def discover_jobs(sources: Dict[str, str]) -> List[Dict[str, Dict[str, str]]]:
                 job_sources[key] = str(path)
                 has_other_sources = True
 
+        # Check for matching subtitle folder
+        job_data = {'sources': job_sources}
+        if subtitle_base_path:
+            matched_sub_folder = _find_matching_subtitle_folder(source1_path, subtitle_base_path)
+            if matched_sub_folder:
+                job_data['subtitle_folder_path'] = str(matched_sub_folder)
+                job_data['subtitle_folder_sync_source'] = subtitle_folder_sync_source
+
         # CHANGE: Always return the job, even with only Source 1
         # This enables remux-only mode for processing a single file
-        return [{'sources': job_sources}]
+        return [job_data]
 
     # --- Batch (Folder) Mode ---
     if source1_path.is_dir():
@@ -51,9 +96,17 @@ def discover_jobs(sources: Dict[str, str]) -> List[Dict[str, Dict[str, str]]]:
                     job_sources[key] = str(match_file)
                     has_other_sources = True
 
+            # Check for matching subtitle folder
+            job_data = {'sources': job_sources}
+            if subtitle_base_path:
+                matched_sub_folder = _find_matching_subtitle_folder(ref_file, subtitle_base_path)
+                if matched_sub_folder:
+                    job_data['subtitle_folder_path'] = str(matched_sub_folder)
+                    job_data['subtitle_folder_sync_source'] = subtitle_folder_sync_source
+
             # CHANGE: Allow single-source batch jobs (remux-only mode)
             # Always include the job, even if no matching files in other sources
-            jobs.append({'sources': job_sources})
+            jobs.append(job_data)
 
         return jobs
 

--- a/vsg_qt/add_job_dialog/ui.py
+++ b/vsg_qt/add_job_dialog/ui.py
@@ -5,7 +5,8 @@ from typing import List, Dict
 
 from PySide6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QPushButton, QDialogButtonBox,
-    QLineEdit, QLabel, QMessageBox, QFileDialog, QScrollArea, QWidget
+    QLineEdit, QLabel, QMessageBox, QFileDialog, QScrollArea, QWidget,
+    QComboBox, QGroupBox
 )
 
 from vsg_core.job_discovery import discover_jobs
@@ -53,6 +54,85 @@ class SourceInputWidget(QWidget):
     def text(self) -> str:
         return self.line_edit.text()
 
+
+class SubtitleFolderWidget(QWidget):
+    """A widget for configuring subtitle folder path and sync source."""
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setAcceptDrops(True)
+
+        layout = QVBoxLayout(self)
+
+        # Path selection row
+        path_layout = QHBoxLayout()
+        path_label = QLabel("Subtitle Folder:")
+        self.path_edit = QLineEdit()
+        self.path_edit.setPlaceholderText("Optional: Folder containing subtitle subfolders")
+        browse_btn = QPushButton("Browse…")
+        browse_btn.clicked.connect(self._browse_for_folder)
+
+        path_layout.addWidget(path_label, 1)
+        path_layout.addWidget(self.path_edit, 4)
+        path_layout.addWidget(browse_btn)
+
+        # Sync source row
+        sync_layout = QHBoxLayout()
+        sync_label = QLabel("Sync to Source:")
+        self.sync_combo = QComboBox()
+        sync_layout.addWidget(sync_label, 1)
+        sync_layout.addWidget(self.sync_combo, 4)
+        sync_layout.addStretch()  # Align with browse button above
+
+        layout.addLayout(path_layout)
+        layout.addLayout(sync_layout)
+
+    def dragEnterEvent(self, event):
+        if event.mimeData().hasUrls():
+            event.acceptProposedAction()
+        else:
+            event.ignore()
+
+    def dropEvent(self, event):
+        if event.mimeData().hasUrls():
+            path = event.mimeData().urls()[0].toLocalFile()
+            self.path_edit.setText(path)
+            event.acceptProposedAction()
+        else:
+            event.ignore()
+
+    def _browse_for_folder(self):
+        dialog = QFileDialog(self, "Select Subtitle Folder")
+        dialog.setFileMode(QFileDialog.FileMode.Directory)
+        if dialog.exec():
+            self.path_edit.setText(dialog.selectedFiles()[0])
+
+    def get_path(self) -> str:
+        return self.path_edit.text().strip()
+
+    def get_sync_source(self) -> str:
+        return self.sync_combo.currentData() or "Source 1"
+
+    def update_available_sources(self, source_count: int):
+        """Updates the sync source dropdown based on number of configured sources."""
+        self.sync_combo.blockSignals(True)
+        current_selection = self.sync_combo.currentData()
+        self.sync_combo.clear()
+
+        # Add available sources
+        for i in range(1, source_count + 1):
+            source_key = f"Source {i}"
+            display_text = f"Source {i}" if i > 1 else "Source 1 (Reference)"
+            self.sync_combo.addItem(display_text, source_key)
+
+        # Restore previous selection if still valid
+        if current_selection:
+            index = self.sync_combo.findData(current_selection)
+            if index != -1:
+                self.sync_combo.setCurrentIndex(index)
+
+        self.sync_combo.blockSignals(False)
+
+
 class AddJobDialog(QDialog):
     """
     A dialog for dynamically adding sources to discover jobs.
@@ -86,6 +166,14 @@ class AddJobDialog(QDialog):
         add_source_btn.clicked.connect(self.add_source_input)
         layout.addWidget(add_source_btn)
 
+        # Subtitle folder configuration section
+        subtitle_group = QGroupBox("Subtitle Folder (Optional)")
+        subtitle_layout = QVBoxLayout()
+        self.subtitle_folder_widget = SubtitleFolderWidget()
+        subtitle_layout.addWidget(self.subtitle_folder_widget)
+        subtitle_group.setLayout(subtitle_layout)
+        layout.addWidget(subtitle_group)
+
         dialog_btns = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         ok_button = dialog_btns.button(QDialogButtonBox.Ok)
         ok_button.setText("Find & Add Jobs")
@@ -101,6 +189,9 @@ class AddJobDialog(QDialog):
         source_widget = SourceInputWidget(source_num)
         self.source_widgets.append(source_widget)
         self.inputs_layout.addWidget(source_widget)
+
+        # Update subtitle folder widget's available sources
+        self.subtitle_folder_widget.update_available_sources(source_num)
 
     def populate_sources_from_paths(self, paths: List[str]):
         """Pre-fills the source inputs from a list of paths."""
@@ -132,8 +223,16 @@ class AddJobDialog(QDialog):
             QMessageBox.warning(self, "Input Required", "Source 1 (Reference) cannot be empty.")
             return
 
+        # Get subtitle folder configuration
+        subtitle_folder_path = self.subtitle_folder_widget.get_path()
+        subtitle_folder_sync_source = self.subtitle_folder_widget.get_sync_source()
+
         try:
-            self.discovered_jobs = discover_jobs(sources)
+            self.discovered_jobs = discover_jobs(
+                sources,
+                subtitle_folder_path=subtitle_folder_path if subtitle_folder_path else None,
+                subtitle_folder_sync_source=subtitle_folder_sync_source
+            )
             if not self.discovered_jobs:
                 QMessageBox.information(self, "No Jobs Found", "No matching jobs could be discovered from the provided paths.")
                 return

--- a/vsg_qt/job_queue_dialog/logic.py
+++ b/vsg_qt/job_queue_dialog/logic.py
@@ -79,7 +79,17 @@ class JobQueueLogic:
         """Retrieves and caches track info for a job."""
         if 'track_info' not in job or job['track_info'] is None:
             try:
-                job['track_info'] = get_track_info_for_dialog(job['sources'], self.runner, self.tool_paths)
+                # Pass subtitle folder info if available in job data
+                subtitle_folder_path = job.get('subtitle_folder_path')
+                subtitle_folder_sync_source = job.get('subtitle_folder_sync_source', 'Source 1')
+
+                job['track_info'] = get_track_info_for_dialog(
+                    job['sources'],
+                    self.runner,
+                    self.tool_paths,
+                    subtitle_folder_path=subtitle_folder_path,
+                    subtitle_folder_sync_source=subtitle_folder_sync_source
+                )
             except Exception as e:
                 QMessageBox.critical(self.v, "Error Analyzing Tracks", f"Could not analyze tracks for {Path(job['sources']['Source 1']).name}:\n{e}")
                 return None

--- a/vsg_qt/track_widget/logic.py
+++ b/vsg_qt/track_widget/logic.py
@@ -14,6 +14,7 @@ class TrackWidgetLogic:
         """Sets the initial state of the UI based on track data."""
         is_subs = self.track_data.get('type') == 'subtitles'
         is_external = self.track_data.get('source') == 'External'
+        is_subtitle_folder = self.track_data.get('source') == 'Subtitle Folder'
 
         # Show/hide controls based on track type
         self.v.cb_forced.setVisible(is_subs)
@@ -28,10 +29,11 @@ class TrackWidgetLogic:
             self.v.cb_convert.setChecked(self.track_data.get('convert_to_ass', False))
             self.v.cb_rescale.setChecked(self.track_data.get('rescale', False))
 
-        # Show the sync dropdown ONLY for external subtitles
-        self.v.sync_to_label.setVisible(is_subs and is_external)
-        self.v.sync_to_combo.setVisible(is_subs and is_external)
-        if is_subs and is_external:
+        # Show the sync dropdown for external subtitles and subtitle folder subtitles
+        show_sync_dropdown = is_subs and (is_external or is_subtitle_folder)
+        self.v.sync_to_label.setVisible(show_sync_dropdown)
+        self.v.sync_to_combo.setVisible(show_sync_dropdown)
+        if show_sync_dropdown:
             self.populate_sync_sources()
 
     def populate_sync_sources(self):
@@ -43,7 +45,9 @@ class TrackWidgetLogic:
         for src in self.available_sources:
              if src != "Source 1":
                 combo.addItem(src, src)
-        saved_sync_source = self.track_data.get('sync_to')
+
+        # Check both 'sync_to' (saved by user) and 'sync_to_source' (from subtitle folder default)
+        saved_sync_source = self.track_data.get('sync_to') or self.track_data.get('sync_to_source')
         if saved_sync_source:
             index = combo.findData(saved_sync_source)
             if index != -1:


### PR DESCRIPTION
Implements a new "Subtitle Folder" source that matches subtitle subfolders to video files by name (stem matching). Subtitles from matched folders appear in the manual selection dialog with configurable sync source.

Features:
- New SubtitleFolderWidget in Add Job dialog with path and sync source config
- Folder name matching in job discovery (e.g., folder "1" matches "1.mkv")
- Subtitle folder scanner using ffprobe for metadata extraction
- Integration with existing track info system and manual selection dialog
- Source-level sync configuration with per-subtitle override option
- Support for .srt, .ass, .ssa, and .sup subtitle files

Example workflow:
1. Source 1: Videos folder with "1.mkv", "2.mkv"
2. Subtitle Folder: Contains subfolders "1/" and "2/" with multiple subs each
3. Configure sync source (e.g., Source 2) for all subtitle folder subs
4. All subs from matching folders appear in manual selection dialog
5. User selects which subs to include in final output

Modified files:
- vsg_core/job_discovery.py: Add subtitle folder matching logic
- vsg_core/extraction/tracks.py: Add subtitle folder scanner and integration
- vsg_qt/add_job_dialog/ui.py: Add subtitle folder configuration UI
- vsg_qt/job_queue_dialog/logic.py: Pass subtitle folder info to track builder
- vsg_qt/track_widget/logic.py: Support "Subtitle Folder" source in sync dropdown