### PR TITLE
Add stepping correction for subtitle-only merges

### DIFF
--- a/vsg_core/orchestrator/steps/analysis_step.py
+++ b/vsg_core/orchestrator/steps/analysis_step.py
@@ -354,10 +354,24 @@ class AnalysisStep:
                             f"[Stepping] Stepping correction will be applied to audio tracks from {source_key}."
                         )
                     else:
+                        # No audio tracks from this source - but subtitles still need stepping correction
                         runner._log_message(
                             f"[Stepping Detected] Stepping detected in {source_key}, but no audio tracks "
-                            f"from this source are being used. Subtitle sync will still use first segment delay."
+                            f"from this source are being used."
                         )
+
+                        # Generate simplified EDL for subtitle adjustment
+                        from vsg_core.correction.stepping import generate_edl_from_correlation
+                        edl = generate_edl_from_correlation(results, config, runner)
+                        if edl:
+                            ctx.stepping_edls[source_key] = edl
+                            runner._log_message(
+                                f"[Stepping] Generated EDL with {len(edl)} segment(s) for subtitle adjustment:"
+                            )
+                            for i, seg in enumerate(edl):
+                                runner._log_message(
+                                    f"  - Segment {i+1}: @{seg.start_s:.1f}s → delay={seg.delay_ms:+d}ms"
+                                )
 
         # Store stepping sources in context for final report
         ctx.stepping_sources = stepping_sources


### PR DESCRIPTION
Previously, stepping correction only applied when audio tracks were being merged. This left subtitles without stepped timing adjustments when only merging subtitles from sources with stepped correlation.

Changes:
- Added generate_edl_from_correlation() function to stepping.py that creates a simplified EDL directly from correlation chunk results
- Modified analysis_step.py to generate and store EDL when stepping is detected but no audio tracks are being merged
- EDL is stored in ctx.stepping_edls so subtitle step can apply corrections

The simplified EDL approach:
- Groups consecutive correlation chunks by delay (within tolerance)
- Creates AudioSegment entries for each delay change boundary
- No drift analysis (drift_rate_ms_s=0.0) since we're not manipulating audio
- Provides time regions and delays needed for subtitle timestamp adjustment

This preserves the existing audio correction flow while enabling subtitle stepping correction for subtitle-only merge scenarios.

Example: When merging only subtitles with stepped delays like:
  - 0-113s: -115ms
  - 113-585s: -10025ms
  - 585s+: -9958ms

The EDL will have 3 segments and subtitles will be adjusted to match.