### PR TITLE
Add boundary spanning modes for subtitle stepping correction

### DIFF
--- a/vsg_core/config.py
+++ b/vsg_core/config.py
@@ -124,6 +124,7 @@ class AppConfig:
             'stepping_scan_end_percentage': 99.0,  # Independent scan end for stepping correction (higher to catch end boundaries)
             'stepping_adjust_subtitles': True,  # Adjust subtitle timestamps to match stepped audio corrections
             'stepping_adjust_subtitles_no_audio': True,  # Apply stepping to subtitles when no audio is merged (uses correlation-based EDL)
+            'stepping_boundary_mode': 'start',  # How to handle subs spanning boundaries: 'start', 'majority', 'midpoint'
         }
         self.settings = self.defaults.copy()
         self.load()

--- a/vsg_core/orchestrator/steps/subtitles_step.py
+++ b/vsg_core/orchestrator/steps/subtitles_step.py
@@ -119,7 +119,8 @@ class SubtitlesStep:
                             stepping_report = apply_stepping_to_subtitles(
                                 str(item.extracted_path),
                                 ctx.stepping_edls[source_key],
-                                runner
+                                runner,
+                                ctx.settings_dict
                             )
                             if stepping_report and 'error' not in stepping_report:
                                 runner._log_message("--- Stepping Adjustment Report ---")
@@ -168,7 +169,8 @@ class SubtitlesStep:
                         stepping_report = apply_stepping_to_subtitles(
                             str(item.extracted_path),
                             ctx.stepping_edls[source_key],
-                            runner
+                            runner,
+                            ctx.settings_dict
                         )
                         if stepping_report and 'error' not in stepping_report:
                             runner._log_message("--- Stepping Adjustment Report ---")

--- a/vsg_qt/options_dialog/tabs.py
+++ b/vsg_qt/options_dialog/tabs.py
@@ -371,6 +371,27 @@ class AnalysisTab(QWidget):
         )
         segment_layout.addRow(self.widgets['stepping_adjust_subtitles_no_audio'])
 
+        self.widgets['stepping_boundary_mode'] = QComboBox()
+        self.widgets['stepping_boundary_mode'].addItems(['start', 'majority', 'midpoint'])
+        self.widgets['stepping_boundary_mode'].setToolTip(
+            "How to handle subtitles that span across stepping boundaries:\n\n"
+            "• Start Time (default):\n"
+            "  Uses the subtitle's start timestamp to determine which delay region it belongs to.\n"
+            "  Fast and simple. Works well for short subtitles (2-3 seconds).\n\n"
+            "• Majority Duration:\n"
+            "  Calculates which delay region the subtitle spends the most time in.\n"
+            "  More accurate for long subtitles or song lyrics that span boundaries.\n"
+            "  Example: A 10-second subtitle spanning a boundary at 5 seconds gets the delay\n"
+            "  of whichever region it occupies for more than 5 seconds.\n\n"
+            "• Midpoint:\n"
+            "  Uses the middle timestamp of the subtitle: (start + end) / 2.\n"
+            "  Simple compromise between start-only and duration-based.\n"
+            "  Better than start-only for moderately long subtitles.\n\n"
+            "Note: This only affects subtitle timing adjustment, not audio stepping correction.\n"
+            "Recommended: Use 'start' for typical dialogue, 'majority' for songs/karaoke."
+        )
+        segment_layout.addRow("Boundary Spanning Mode:", self.widgets['stepping_boundary_mode'])
+
         main_layout.addWidget(segment_group)
 
         main_layout.addStretch(1)


### PR DESCRIPTION
Implemented three modes to handle subtitles that span stepping boundaries, giving users control over how timestamps are assigned when a subtitle appears across multiple delay regions.

New Modes:
1. Start Time (default) - Uses subtitle's start timestamp (fast, current behavior)
2. Majority Duration - Uses the delay region where subtitle spends most time
3. Midpoint - Uses the middle timestamp: (start + end) / 2

Implementation Details:
- Added 'stepping_boundary_mode' setting to config.py (default: 'start')
- Added dropdown UI control in Analysis tab > Stepping Correction section
- Rewrote _get_offset_at_time() in stepping_adjust.py to support all 3 modes
- Added _spans_boundary() helper to detect and count boundary-spanning subs
- Enhanced reporting to show boundary mode and spanning subtitle count

Mode Logic:
- Start: Simple and fast, works well for short dialogue subtitles
- Majority: Calculates overlap duration in each region, picks the region with most time. Best for long subtitles (songs, karaoke) spanning boundaries
- Midpoint: Uses (start+end)/2, simple compromise for moderate lengths

The modes work for BOTH:
- Full audio stepping correction (when audio is being merged)
- Subtitle-only stepping correction (correlation-based EDL)

Example log output:
[SteppingAdjust] Adjusted 234/250 subtitles using 'majority' mode. Max adjustment: -9925ms [SteppingAdjust] 3 subtitle(s) span stepping boundaries

Note: This only affects subtitle timestamp adjustment, not audio stepping. Audio stepping correction remains completely untouched.