### PR TITLE
Make First Stable stability options UI-only, separate from stepping

### DIFF
--- a/vsg_core/orchestrator/steps/analysis_step.py
+++ b/vsg_core/orchestrator/steps/analysis_step.py
@@ -274,7 +274,9 @@ class AnalysisStep:
 
                     if has_audio_from_source:
                         # Stepping correction will run, so use first segment delay
-                        first_segment_delay = _find_first_stable_segment_delay(results, runner, config)
+                        # Use hardcoded stability criteria (separate from First Stable delay selection mode)
+                        stepping_config = {'first_stable_min_chunks': 3, 'first_stable_skip_unstable': True}
+                        first_segment_delay = _find_first_stable_segment_delay(results, runner, stepping_config)
                         if first_segment_delay is not None:
                             stepping_override_delay = first_segment_delay
                             runner._log_message(f"[Stepping Detected] Found stepping in {source_key}")


### PR DESCRIPTION
Changes:
- First Stable min chunks and skip unstable controls now only enabled when "First Stable" delay selection mode is selected
- Updated tooltips to clarify these are for First Stable mode only
- Stepping detection now uses hardcoded stability criteria (min_chunks=3, skip_unstable=True) instead of reading from config
- Clarified in tooltip that stepping correction should use Segmented Audio settings, not First Stable mode

This separates the concerns: First Stable mode is for files with authoring issues where sync changes mid-file, while stepping correction has its own dedicated settings in the Segmented Audio section.