### PR TITLE
Add separate configurable first stable settings for stepping correction

### DIFF
--- a/vsg_core/config.py
+++ b/vsg_core/config.py
@@ -118,6 +118,8 @@ class AppConfig:
 
             # --- Stepping Correction Enhancements ---
             'stepping_min_cluster_size': 3,  # Minimum chunks per cluster to qualify as stepping
+            'stepping_first_stable_min_chunks': 3,  # Min chunks for first stable segment (stepping delay selection)
+            'stepping_first_stable_skip_unstable': True,  # Skip unstable segments when detecting stepping delay
             'stepping_fill_mode': 'silence',  # 'auto', 'silence', or 'content' - how to fill delay gaps
             'stepping_diagnostics_verbose': True,  # Enable detailed cluster composition reports
             'stepping_content_correlation_threshold': 0.5,  # Min correlation for content extraction (for auto/content modes)

--- a/vsg_core/orchestrator/steps/analysis_step.py
+++ b/vsg_core/orchestrator/steps/analysis_step.py
@@ -274,8 +274,11 @@ class AnalysisStep:
 
                     if has_audio_from_source:
                         # Stepping correction will run, so use first segment delay
-                        # Use hardcoded stability criteria (separate from First Stable delay selection mode)
-                        stepping_config = {'first_stable_min_chunks': 3, 'first_stable_skip_unstable': True}
+                        # Use stepping-specific stability criteria (separate from First Stable delay selection mode)
+                        stepping_config = {
+                            'first_stable_min_chunks': config.get('stepping_first_stable_min_chunks', 3),
+                            'first_stable_skip_unstable': config.get('stepping_first_stable_skip_unstable', True)
+                        }
                         first_segment_delay = _find_first_stable_segment_delay(results, runner, stepping_config)
                         if first_segment_delay is not None:
                             stepping_override_delay = first_segment_delay

--- a/vsg_qt/options_dialog/tabs.py
+++ b/vsg_qt/options_dialog/tabs.py
@@ -294,6 +294,34 @@ class AnalysisTab(QWidget):
         segment_layout.addRow("Quality Mode:", self.widgets['stepping_quality_mode'])
         segment_layout.addRow("Filtered Fallback:", self.widgets['stepping_filtered_fallback'])
 
+        # First Stable Delay Selection (for stepping)
+        self.widgets['stepping_first_stable_min_chunks'] = QSpinBox()
+        self.widgets['stepping_first_stable_min_chunks'].setRange(1, 100)
+        self.widgets['stepping_first_stable_min_chunks'].setToolTip(
+            "[Stepping Delay Selection]\n\n"
+            "Minimum consecutive chunks required for a segment to be considered 'stable'\n"
+            "when determining the base delay for stepping correction.\n\n"
+            "Higher values = more strict (avoids false positives at file start)\n"
+            "Lower values = more lenient (may catch brief stable periods)\n\n"
+            "Note: This is separate from 'First Stable' delay selection mode in Analysis.\n"
+            "Default: 3 chunks"
+        )
+
+        self.widgets['stepping_first_stable_skip_unstable'] = QCheckBox()
+        self.widgets['stepping_first_stable_skip_unstable'].setToolTip(
+            "[Stepping Delay Selection]\n\n"
+            "When enabled, skips segments that don't meet the minimum chunk count\n"
+            "and looks for the next stable segment.\n\n"
+            "Useful for avoiding offset beginnings (e.g., 2 chunks at wrong delay\n"
+            "before the rest of the file stabilizes).\n\n"
+            "When disabled, always uses the very first segment regardless of size.\n\n"
+            "Note: This is separate from 'First Stable' delay selection mode in Analysis.\n"
+            "Default: Enabled"
+        )
+
+        segment_layout.addRow("  ↳ First Stable Min Chunks:", self.widgets['stepping_first_stable_min_chunks'])
+        segment_layout.addRow("  ↳ First Stable Skip Unstable:", self.widgets['stepping_first_stable_skip_unstable'])
+
         # Add separator
         separator = QLabel()
         separator.setFixedHeight(10)


### PR DESCRIPTION
Previously stepping detection used hardcoded values after separating from First Stable delay selection mode. Now both features have their own independent configuration:

Analysis tab settings (for First Stable delay selection mode):
- first_stable_min_chunks
- first_stable_skip_unstable

Segmented Audio tab settings (for stepping correction):
- stepping_first_stable_min_chunks
- stepping_first_stable_skip_unstable

Both default to 3 chunks minimum and skip_unstable=True, but can now be configured independently based on the use case. This gives users full control over stability criteria in both scenarios.