### PR TITLE
Fix broken AnalysisTab after stepping section removal

### DIFF
--- a/vsg_qt/options_dialog/tabs.py
+++ b/vsg_qt/options_dialog/tabs.py
@@ -199,17 +199,12 @@ class AnalysisTab(QWidget):
         main_layout.addWidget(adv_group)
 
         self.widgets['filtering_method'].currentTextChanged.connect(self._update_filter_options)
-        self.widgets['segment_resample_engine'].currentTextChanged.connect(self._update_rb_group_visibility)
         self.widgets['delay_selection_mode'].currentTextChanged.connect(self._update_first_stable_options)
-        self._update_rb_group_visibility(self.widgets['segment_resample_engine'].currentText())
         self._update_filter_options(self.widgets['filtering_method'].currentText())
         self._update_first_stable_options(self.widgets['delay_selection_mode'].currentText())
 
     def _update_filter_options(self, text: str):
         self.cutoff_container.setVisible(text == "Low-Pass Filter")
-
-    def _update_rb_group_visibility(self, text: str):
-        self.rb_group.setVisible(text == 'rubberband')
 
     def _update_first_stable_options(self, text: str):
         is_first_stable = (text == "First Stable")
@@ -679,6 +674,10 @@ class SteppingTab(QWidget):
         )
 
         segment_layout.addRow(self.widgets['stepping_diagnostics_verbose'])
+
+        # Connect signal handlers
+        self.widgets['segment_resample_engine'].currentTextChanged.connect(self._update_rb_group_visibility)
+        self._update_rb_group_visibility(self.widgets['segment_resample_engine'].currentText())
 
         main_layout.addWidget(segment_group)
 


### PR DESCRIPTION
Issue: AnalysisTab had leftover code referencing widgets that were moved to SteppingTab:
- segment_resample_engine connection causing KeyError
- _update_rb_group_visibility method referencing non-existent rb_group

Changes:
- Remove segment_resample_engine connection from AnalysisTab
- Remove _update_rb_group_visibility method from AnalysisTab
- Add missing connection in SteppingTab for rubberband group visibility

The rubberband settings group now properly shows/hides in SteppingTab based on the selected resample engine.

Fixes error: KeyError: 'segment_resample_engine' at tabs.py:202