### PR TITLE
Add timing sync mode selection (Mode 1 & 2)

### DIFF
--- a/vsg_core/config.py
+++ b/vsg_core/config.py
@@ -77,6 +77,9 @@ class AppConfig:
             'archive_logs': True,
             'auto_apply_strict': False,
 
+            # --- Timing Sync Mode ---
+            'sync_mode': 'positive_only',
+
             # --- Post-merge options ---
             'post_mux_normalize_timestamps': False,
             'post_mux_strip_tags': False,

--- a/vsg_qt/options_dialog/tabs.py
+++ b/vsg_qt/options_dialog/tabs.py
@@ -188,7 +188,25 @@ class AnalysisTab(QWidget):
         lang_layout.addRow("Other Sources Language:", self.widgets['analysis_lang_others'])
         main_layout.addWidget(lang_group)
 
-        adv_group = QGroupBox("Step 5: Advanced Tweaks & Diagnostics")
+        timing_mode_group = QGroupBox("Step 5: Timing Sync Mode")
+        timing_mode_layout = QFormLayout(timing_mode_group)
+        self.widgets['sync_mode'] = QComboBox()
+        self.widgets['sync_mode'].addItems(['positive_only', 'allow_negative'])
+        self.widgets['sync_mode'].setToolTip(
+            "Controls how timing delays are applied:\n\n"
+            "• positive_only (Default): Shifts all tracks to eliminate negative delays.\n"
+            "  Source 1 remains the reference timeline. Best for standard merges.\n"
+            "  Exception: When only subtitles (no audio) from other sources are merged,\n"
+            "  negative delays are automatically allowed.\n\n"
+            "• allow_negative: Allows negative delays for secondary sources.\n"
+            "  Source 1 remains the reference (delay = 0). Useful when merging early\n"
+            "  releases (e.g., JPN Blu-ray + web audio) that will be remuxed later\n"
+            "  with a US Blu-ray in positive_only mode to add lossless audio."
+        )
+        timing_mode_layout.addRow("Sync Mode:", self.widgets['sync_mode'])
+        main_layout.addWidget(timing_mode_group)
+
+        adv_group = QGroupBox("Step 6: Advanced Tweaks & Diagnostics")
         adv_layout = QVBoxLayout(adv_group)
         self.widgets['use_soxr'] = QCheckBox("Use High-Quality Resampling (SoXR)"); self.widgets['use_soxr'].setToolTip("Use the high-quality SoXR resampler library when decoding audio.\nSlower but more accurate than the default resampler.")
         self.widgets['audio_peak_fit'] = QCheckBox("Enable Sub-Sample Peak Fitting (SCC only)"); self.widgets['audio_peak_fit'].setToolTip("For Standard Correlation (SCC), use parabolic interpolation to find a more precise, sub-sample peak.\nMay improve accuracy slightly.")


### PR DESCRIPTION
Implements two sync modes for delay handling:

**Mode 1: positive_only (Default)**
- Existing behavior preserved exactly
- Applies global shift to eliminate negative delays when secondary audio exists
- Exception: Subtitle-only merges allow negatives (unchanged)
- Use case: Standard merges where Source 1 is the definitive timeline

**Mode 2: allow_negative**
- Forces negative delays to be allowed even with secondary audio
- Source 1 remains reference (delay = 0)
- No global shift applied
- Use case: Early JPN BD + web audio, later remux with US BD in Mode 1

Changes:
- Added 'sync_mode' config setting (default: 'positive_only')
- Added UI dropdown in Analysis tab Step 5
- Modified analysis_step.py to handle mode selection
- Preserves all existing default behavior

Mode 3 (preserve_existing) will be implemented separately.