### PR TITLE
Improve sync mode logging and auditor awareness

### DIFF
--- a/vsg_core/mux/options_builder.py
+++ b/vsg_core/mux/options_builder.py
@@ -50,10 +50,21 @@ class MkvmergeOptionsBuilder:
         forced_sub_idx = self._first_index(final_items, kind='subtitles', predicate=lambda it: it.is_forced_display)
 
         order_entries: List[str] = []
+
+        # Log sync mode for debugging
+        sync_mode = self.config.get('sync_mode', 'positive_only')
+        self.log(f"\n[MUX] Applying delays (sync_mode: {sync_mode}, global_shift: {plan.delays.global_shift_ms}ms):")
+
         for i, item in enumerate(final_items):
             tr = item.track
 
             delay_ms = self._effective_delay_ms(plan, item)
+
+            # Log delay being applied for debugging
+            if tr.type.value in ['audio', 'video']:
+                track_name = tr.props.name or f"Track {tr.id}"
+                self.log(f"  → {tr.type.value.capitalize()} '{track_name}' ({tr.source}): {delay_ms:+d}ms")
+
             is_default = (i == first_video_idx) or (i == default_audio_idx) or (i == default_sub_idx)
 
             # NEW: Use custom language if set, otherwise use original from track

--- a/vsg_core/orchestrator/steps/context.py
+++ b/vsg_core/orchestrator/steps/context.py
@@ -49,6 +49,9 @@ class Context:
     # A flag to determine if a global shift is necessary
     global_shift_is_required: bool = False
 
+    # Timing sync mode ('positive_only', 'allow_negative', or 'preserve_existing')
+    sync_mode: str = 'positive_only'
+
     # NEW: Track which sources had stepping detected (for final report)
     stepping_sources: List[str] = field(default_factory=list)
 


### PR DESCRIPTION
**Logging Improvements:**
- Added prominent sync mode banner at start of analysis
- Shows which mode is active (POSITIVE_ONLY or ALLOW_NEGATIVE)
- Added sync mode to final delay summary
- Muxing now logs delays being applied to each audio/video track
- Added helpful notes about negative delay retention

**Auditor Improvements:**
- Auditor now reads sync_mode from context
- Shows sync mode in mismatch warnings for better debugging
- Provides helpful context when negative delays expected but positive found
- Helps identify chain correction or muxing issues in allow_negative mode

**Context Enhancement:**
- Added sync_mode field to Context dataclass
- Stored during analysis for use by muxer and auditor

These changes help diagnose delay mismatches and make it clear which sync mode is being used throughout the pipeline.

Related to: Allow negative timing sync mode implementation