### PR TITLE
Fix: Add sync_mode to AppSettings and fix options_builder

### DIFF
--- a/vsg_core/models/settings.py
+++ b/vsg_core/models/settings.py
@@ -34,6 +34,7 @@ class AppSettings:
     log_show_options_json: bool
     archive_logs: bool
     auto_apply_strict: bool
+    sync_mode: str
 
     @classmethod
     def from_config(cls, cfg: dict) -> "AppSettings":
@@ -70,4 +71,5 @@ class AppSettings:
             log_show_options_json=bool(cfg['log_show_options_json']),
             archive_logs=bool(cfg['archive_logs']),
             auto_apply_strict=bool(cfg.get('auto_apply_strict', False)),
+            sync_mode=str(cfg.get('sync_mode', 'positive_only')),
         )

--- a/vsg_core/mux/options_builder.py
+++ b/vsg_core/mux/options_builder.py
@@ -50,21 +50,10 @@ class MkvmergeOptionsBuilder:
         forced_sub_idx = self._first_index(final_items, kind='subtitles', predicate=lambda it: it.is_forced_display)
 
         order_entries: List[str] = []
-
-        # Log sync mode for debugging
-        sync_mode = self.config.get('sync_mode', 'positive_only')
-        self.log(f"\n[MUX] Applying delays (sync_mode: {sync_mode}, global_shift: {plan.delays.global_shift_ms}ms):")
-
         for i, item in enumerate(final_items):
             tr = item.track
 
             delay_ms = self._effective_delay_ms(plan, item)
-
-            # Log delay being applied for debugging
-            if tr.type.value in ['audio', 'video']:
-                track_name = tr.props.name or f"Track {tr.id}"
-                self.log(f"  → {tr.type.value.capitalize()} '{track_name}' ({tr.source}): {delay_ms:+d}ms")
-
             is_default = (i == first_video_idx) or (i == default_audio_idx) or (i == default_sub_idx)
 
             # NEW: Use custom language if set, otherwise use original from track


### PR DESCRIPTION
**Bug Fix:**
- Added sync_mode field to AppSettings dataclass
- Added sync_mode to from_config method with default 'positive_only'
- Removed invalid self.config and self.log references from options_builder

**Issue:**
MkvmergeOptionsBuilder.build() tried to access self.config.get() and self.log() but the class doesn't have those attributes (it's a stateless builder).

**Solution:**
- Removed logging from options_builder (analysis_step already logs mode)
- sync_mode now properly passed through AppSettings to all components

Fixes: 'MkvmergeOptionsBuilder' object has no attribute 'config'