### PR TITLE
Add configurable track naming for stepping correction output

### DIFF
--- a/vsg_core/config.py
+++ b/vsg_core/config.py
@@ -131,6 +131,10 @@ class AppConfig:
             'stepping_adjust_subtitles_no_audio': True,  # Apply stepping to subtitles when no audio is merged (uses correlation-based EDL)
             'stepping_boundary_mode': 'start',  # How to handle subs spanning boundaries: 'start', 'majority', 'midpoint'
 
+            # --- Track Naming ---
+            'stepping_corrected_track_label': '',  # Label for corrected audio in final MKV (empty = no label, e.g., "Stepping Corrected")
+            'stepping_preserved_track_label': '',  # Label for preserved original in final MKV (empty = no label, e.g., "Original")
+
             # --- Silence-Aware Boundary Snapping ---
             'stepping_snap_to_silence': True,  # Enable boundary snapping to silence zones
             'stepping_silence_search_window_s': 3.0,  # Search window in seconds (±N seconds from detected boundary)

--- a/vsg_core/correction/stepping.py
+++ b/vsg_core/correction/stepping.py
@@ -1344,12 +1344,20 @@ def run_stepping_correction(ctx: Context, runner: CommandRunner) -> Context:
                     preserved_item.is_preserved = True
                     preserved_item.is_default = False
                     original_props = preserved_item.track.props
+
+                    # Build preserved track name from config
+                    preserved_label = self.config.get('stepping_preserved_track_label', '')
+                    if preserved_label:
+                        preserved_name = f"{original_props.name} ({preserved_label})" if original_props.name else preserved_label
+                    else:
+                        preserved_name = original_props.name if original_props.name else None
+
                     preserved_item.track = Track(
                         source=preserved_item.track.source, id=preserved_item.track.id, type=preserved_item.track.type,
                         props=StreamProps(
                             codec_id=original_props.codec_id,
                             lang=original_props.lang,
-                            name=f"{original_props.name} (Original)" if original_props.name else "Original"
+                            name=preserved_name
                         )
                     )
 
@@ -1357,12 +1365,20 @@ def run_stepping_correction(ctx: Context, runner: CommandRunner) -> Context:
                     target_item.extracted_path = corrected_path
                     target_item.is_corrected = True
                     target_item.container_delay_ms = 0  # FIXED: New FLAC has no container delay
+
+                    # Build corrected track name from config
+                    corrected_label = self.config.get('stepping_corrected_track_label', '')
+                    if corrected_label:
+                        corrected_name = f"{original_props.name} ({corrected_label})" if original_props.name else corrected_label
+                    else:
+                        corrected_name = original_props.name if original_props.name else None
+
                     target_item.track = Track(
                         source=target_item.track.source, id=target_item.track.id, type=target_item.track.type,
                         props=StreamProps(
                             codec_id="FLAC",
                             lang=original_props.lang,
-                            name=f"{original_props.name} (Stepping Corrected)" if original_props.name else "Stepping Corrected"  # FIXED: Clearer name
+                            name=corrected_name
                         )
                     )
                     target_item.apply_track_name = True

--- a/vsg_qt/options_dialog/tabs.py
+++ b/vsg_qt/options_dialog/tabs.py
@@ -755,7 +755,49 @@ class SteppingTab(QWidget):
         segment_layout.addRow("  Outlier Sensitivity:", self.widgets['segment_drift_outlier_sensitivity'])
         segment_layout.addRow("  Scan Buffer %:", self.widgets['segment_drift_scan_buffer_pct'])
 
-        # ===== SECTION 6: SUBTITLE ADJUSTMENT =====
+        # ===== SECTION 6: TRACK NAMING =====
+        # Controls track naming in final MKV output
+        segment_layout.addRow(QLabel(""))
+        segment_layout.addRow(QLabel("<b>═══ Track Naming ═══</b>"))
+        segment_layout.addRow(QLabel("<i>Controls track naming in final MKV output</i>"))
+
+        self.widgets['stepping_corrected_track_label'] = QLineEdit()
+        self.widgets['stepping_corrected_track_label'].setPlaceholderText("Leave empty for no label")
+        self.widgets['stepping_corrected_track_label'].setToolTip(
+            "Label added to corrected audio tracks in final MKV.\n"
+            "If original track has a name, label is added in brackets.\n"
+            "If original track has no name, only the label is used.\n\n"
+            "Examples:\n"
+            "  Label = 'Stepping Corrected':\n"
+            "    'Surround 5.1' → 'Surround 5.1 (Stepping Corrected)'\n"
+            "    (no name) → 'Stepping Corrected'\n\n"
+            "  Label = '' (empty):\n"
+            "    'Surround 5.1' → 'Surround 5.1'\n"
+            "    (no name) → (no name)\n\n"
+            "Temp files still use 'corrected' for tracking.\n"
+            "Default: Empty (no label)"
+        )
+
+        self.widgets['stepping_preserved_track_label'] = QLineEdit()
+        self.widgets['stepping_preserved_track_label'].setPlaceholderText("Leave empty for no label")
+        self.widgets['stepping_preserved_track_label'].setToolTip(
+            "Label added to preserved original tracks in final MKV.\n"
+            "Preserved originals are kept when 'Preserve Original' is enabled.\n"
+            "Follows same naming rules as corrected tracks.\n\n"
+            "Examples:\n"
+            "  Label = 'Original':\n"
+            "    'Surround 5.1' → 'Surround 5.1 (Original)'\n"
+            "    (no name) → 'Original'\n\n"
+            "  Label = '' (empty):\n"
+            "    'Surround 5.1' → 'Surround 5.1'\n"
+            "    (no name) → (no name)\n\n"
+            "Default: Empty (no label)"
+        )
+
+        segment_layout.addRow("Corrected Track Label:", self.widgets['stepping_corrected_track_label'])
+        segment_layout.addRow("Preserved Track Label:", self.widgets['stepping_preserved_track_label'])
+
+        # ===== SECTION 7: SUBTITLE ADJUSTMENT =====
         # Controls subtitle timestamp adjustments for stepped sources
         segment_layout.addRow(QLabel(""))
         segment_layout.addRow(QLabel("<b>═══ Subtitle Adjustment ═══</b>"))
@@ -792,7 +834,7 @@ class SteppingTab(QWidget):
         segment_layout.addRow(self.widgets['stepping_adjust_subtitles_no_audio'])
         segment_layout.addRow("Boundary Spanning Mode:", self.widgets['stepping_boundary_mode'])
 
-        # ===== SECTION 7: DIAGNOSTICS =====
+        # ===== SECTION 8: DIAGNOSTICS =====
         # Controls diagnostic logging and debugging output
         segment_layout.addRow(QLabel(""))
         segment_layout.addRow(QLabel("<b>═══ Diagnostics ═══</b>"))


### PR DESCRIPTION
Adds user control over track naming in final MKV output for stepping-corrected and preserved original audio tracks. Users can now customize or remove the labels that appear in brackets.

Configuration Options:
- stepping_corrected_track_label: Label for corrected tracks (default: empty)
- stepping_preserved_track_label: Label for preserved originals (default: empty)

Behavior:
- If label is set and track has a name: "Name (Label)"
- If label is set and no track name: "Label"
- If label is empty and track has a name: "Name"
- If label is empty and no track name: (no name)

Examples:
  Label='Stepping Corrected', Track='Surround 5.1' → 'Surround 5.1 (Stepping Corrected)'

  Label='', Track='Surround 5.1' → 'Surround 5.1'

UI Controls:
- Added new "Track Naming" section in Stepping tab
- Text input fields with examples and detailed tooltips
- Positioned before Subtitle Adjustment section

Note: Temp file naming still uses 'corrected' for internal tracking. Only the final MKV track names are affected.