### PR TITLE
Suppress numpy division warnings in drift detection correlation calcu…

### DIFF
--- a/vsg_core/analysis/drift_detection.py
+++ b/vsg_core/analysis/drift_detection.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 import json
+import warnings
 from typing import List, Dict, Any
 
 import numpy as np
@@ -535,7 +536,9 @@ def diagnose_audio_issue(
 
     if abs(slope) > slope_threshold:
         y_predicted = slope * times + intercept
-        correlation_matrix = np.corrcoef(delays, y_predicted)
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', 'invalid value encountered in divide')
+            correlation_matrix = np.corrcoef(delays, y_predicted)
         r_squared = correlation_matrix[0, 1]**2
 
         if r_squared > r2_threshold:


### PR DESCRIPTION
…lations

The numpy.corrcoef() call in drift detection was generating "invalid value encountered in divide" warnings when calculating correlations. This occurs legitimately when data has zero variance (stddev=0), and numpy handles it correctly by returning NaN. Added warnings.catch_warnings() context to suppress these expected warnings, matching the approach used in stepping.py.