### PR TITLE
Fix settings dialog crash when loading new subtitle sync options

### DIFF
--- a/vsg_qt/options_dialog/logic.py
+++ b/vsg_qt/options_dialog/logic.py
@@ -37,6 +37,9 @@ class OptionsLogic:
 
     def _set_widget_val(self, widget, value):
         from PySide6.QtWidgets import QSpinBox, QDoubleSpinBox, QComboBox, QCheckBox, QWidget, QLineEdit
+        # Skip if value is None (config key doesn't exist yet)
+        if value is None:
+            return
         if isinstance(widget, QCheckBox):
             widget.setChecked(bool(value))
         elif isinstance(widget, (QSpinBox, QDoubleSpinBox)):


### PR DESCRIPTION
Handle None values gracefully when config keys don't exist yet. This fixes the TypeError when opening settings before the new subtitle_sync_mode and subtitle_target_fps keys are saved.