### PR TITLE
Add multiple frame timing modes for subtitle sync

### DIFF
--- a/vsg_core/orchestrator/steps/subtitles_step.py
+++ b/vsg_core/orchestrator/steps/subtitles_step.py
@@ -228,7 +228,8 @@ class SubtitlesStep:
                                 delay_ms,
                                 target_fps,
                                 runner,
-                                ctx.settings_dict
+                                ctx.settings_dict,
+                                video_path=source1_file  # For VFR mode
                             )
 
                             if frame_sync_report and 'error' not in frame_sync_report:

--- a/vsg_qt/options_dialog/tabs.py
+++ b/vsg_qt/options_dialog/tabs.py
@@ -968,8 +968,30 @@ class SubtitleSyncTab(QWidget):
             "  - 59.940 fps (60000/1001) - High frame rate"
         )
 
+        self.widgets['frame_sync_mode'] = QComboBox()
+        self.widgets['frame_sync_mode'].addItems(['middle', 'aegisub', 'vfr'])
+        self.widgets['frame_sync_mode'].setToolTip(
+            "Frame timing algorithm (for frame-perfect mode):\n\n"
+            "• middle (Default): Targets middle of frame display window\n"
+            "  - Uses +0.5 frame offset\n"
+            "  - After centisecond rounding: Still lands in correct frame\n"
+            "  - Good balance of accuracy and safety\n\n"
+            "• aegisub: Aegisub-style timing\n"
+            "  - Rounds UP to next centisecond\n"
+            "  - Matches Aegisub's internal algorithm\n"
+            "  - May be closer to what release groups expect\n"
+            "  - Recommended if 'middle' mode has occasional frame errors\n\n"
+            "• vfr: VideoTimestamps-based (requires library)\n"
+            "  - Uses actual frame timestamps from video container\n"
+            "  - Required for Variable Frame Rate videos\n"
+            "  - Most accurate for mixed-framerate content\n"
+            "  - Requires: pip install VideoTimestamps\n\n"
+            "Note: This only applies when 'frame-perfect' sync mode is selected above."
+        )
+
         sync_layout.addRow("Sync Mode:", self.widgets['subtitle_sync_mode'])
         sync_layout.addRow("Target FPS:", self.widgets['subtitle_target_fps'])
+        sync_layout.addRow("Frame Timing:", self.widgets['frame_sync_mode'])
 
         # Info label
         info_label = QLabel(


### PR DESCRIPTION
Implements three frame timing algorithms to solve the remaining 20% subtitle sync issues:

## NEW MODES:

**1. Middle Mode (default, current behavior):**
- Uses +0.5 frame offset to target middle of frame window
- Frame 24: 1022ms → CS rounds to 1020ms
- Safe and reliable for most cases

**2. Aegisub Mode (NEW - RECOMMENDED TO TRY):**
- Matches Aegisub's algorithm: ceil to centisecond
- Frame 24: 1010ms (already rounded to CS)
- Closer to what release groups expect
- May fix the remaining 20% of problematic moving subtitles

**3. VFR Mode (NEW):**
- Uses VideoTimestamps library for actual video frame times
- Handles Variable Frame Rate videos correctly
- Most accurate for mixed-framerate content
- Requires: pip install VideoTimestamps

## CHANGES:

vsg_core/subtitles/frame_sync.py:
- Renamed functions: time_to_frame_middle, frame_to_time_middle
- Added: time_to_frame_aegisub, frame_to_time_aegisub
- Added: time_to_frame_vfr, frame_to_time_vfr
- Updated apply_frame_perfect_sync() to dispatch based on mode
- Kept legacy aliases for backwards compatibility

vsg_qt/options_dialog/tabs.py:
- Added 'Frame Timing' dropdown with 3 modes
- Comprehensive tooltips explaining each mode

vsg_core/orchestrator/steps/subtitles_step.py:
- Pass video_path to apply_frame_perfect_sync for VFR support

## USAGE:

Settings → Subtitle Timing → Frame Timing dropdown:
- Try 'aegisub' mode first (most likely fix)
- Use 'vfr' if videos have variable framerate
- Keep 'middle' as fallback

## TECHNICAL DETAILS:

Aegisub mode rounds UP to next centisecond:
- Frame 24 at 23.976fps = 1001.001ms exact
- ceil(1001.001 / 10) × 10 = 1010ms
- Still safely within frame 24 window (1001-1043ms)
- But 10ms earlier than middle mode (1020ms)

This timing difference may be critical for moving subtitles with millisecond-precision animation tags (\move, \t).