### PR TITLE
Make frame-perfect adjustments optional and clean up VFR mode

### DIFF
--- a/vsg_core/config.py
+++ b/vsg_core/config.py
@@ -24,6 +24,8 @@ class AppConfig:
             'subtitle_sync_mode': 'time-based',
             'subtitle_target_fps': 0.0,
             'frame_sync_mode': 'middle',
+            'frame_shift_rounding': 'round',
+            'frame_sync_fix_zero_duration': False,
 
             # --- Timing Fix Settings ---
             'timing_fix_enabled': False,


### PR DESCRIPTION
Changes to frame-perfect mode:
1. Remove 'vfr' from frame_sync_mode dropdown
   - VFR videos should use top-level 'videotimestamps' mode instead
   - Simplifies UI and avoids confusion

2. Add optional frame shift rounding setting
   - New setting: frame_shift_rounding (round/floor/ceil)
   - Default: 'round' (current behavior)
   - Allows testing if consistent ±1 frame errors are from rounding

3. Add optional zero-duration event fix
   - New setting: frame_sync_fix_zero_duration (checkbox)
   - Default: False (disabled)
   - When disabled, lets conversion errors be visible
   - When enabled, adds 1 frame to end if end ≤ start

4. Update apply_frame_perfect_sync():
   - Use configured rounding method instead of hardcoded round()
   - Apply zero-duration fix only if setting enabled
   - Remove all VFR mode handling
   - Simplified to only handle middle/aegisub modes

Changes to videotimestamps mode:
1. Remove frame shift rounding (was accidentally copied)
2. Remove zero-duration fix (was accidentally copied)
3. Use pure time-based delay application
   - Apply delay to timestamps directly using Fraction precision
   - Convert through VideoTimestamps for frame accuracy
   - No custom fixes or adjustments

UI changes:
- Remove 'vfr' from Frame Timing dropdown
- Add Frame Rounding dropdown (round/floor/ceil)
- Add "Fix zero-duration events" checkbox
- Update tooltips to explain new options
- New settings only enabled for frame-perfect mode

Config changes:
- Add 'frame_shift_rounding': 'round'
- Add 'frame_sync_fix_zero_duration': False

This allows testing three scenarios:
1. videotimestamps - Pure library, no adjustments
2. frame-perfect with adjustments OFF - Raw middle/aegisub math
3. frame-perfect with adjustments ON - Current behavior (default)