### PR TITLE
Fix VideoTimestamps mode to use TimeType.EXACT and add RoundingMethod…

### DIFF
--- a/vsg_core/config.py
+++ b/vsg_core/config.py
@@ -26,6 +26,7 @@ class AppConfig:
             'frame_sync_mode': 'middle',
             'frame_shift_rounding': 'round',
             'frame_sync_fix_zero_duration': False,
+            'videotimestamps_rounding': 'round',
 
             # --- Timing Fix Settings ---
             'timing_fix_enabled': False,

--- a/vsg_qt/options_dialog/tabs.py
+++ b/vsg_qt/options_dialog/tabs.py
@@ -1030,11 +1030,29 @@ class SubtitleSyncTab(QWidget):
             "Only enable if you have subtitles with invalid durations."
         )
 
+        self.widgets['videotimestamps_rounding'] = QComboBox()
+        self.widgets['videotimestamps_rounding'].addItems(['round', 'floor'])
+        self.widgets['videotimestamps_rounding'].setToolTip(
+            "VideoTimestamps RoundingMethod (for videotimestamps sync mode):\n\n"
+            "Controls how the VideoTimestamps library rounds presentation timestamps.\n\n"
+            "• round (Default): Round half up\n"
+            "  - Rounds to nearest integer (.5 and above rounds up)\n"
+            "  - Most accurate for general use\n"
+            "  - Balanced rounding\n\n"
+            "• floor: Always round down\n"
+            "  - Conservative rounding (never exceeds actual timestamp)\n"
+            "  - Matches Aegisub's int() floor division\n"
+            "  - Try this if subs are consistently 1 frame late\n\n"
+            "This setting only applies when 'videotimestamps' sync mode is selected.\n"
+            "Works with TimeType.EXACT for precise video player frame timing."
+        )
+
         sync_layout.addRow("Sync Mode:", self.widgets['subtitle_sync_mode'])
         sync_layout.addRow("Target FPS:", self.widgets['subtitle_target_fps'])
         sync_layout.addRow("Frame Timing:", self.widgets['frame_sync_mode'])
         sync_layout.addRow("Frame Rounding:", self.widgets['frame_shift_rounding'])
         sync_layout.addRow("", self.widgets['frame_sync_fix_zero_duration'])
+        sync_layout.addRow("VTS Rounding:", self.widgets['videotimestamps_rounding'])
 
         # Info label
         info_label = QLabel(
@@ -1073,6 +1091,9 @@ class SubtitleSyncTab(QWidget):
         # Frame shift rounding and zero-duration fix only apply to frame-perfect mode
         self.widgets['frame_shift_rounding'].setEnabled(is_frame_perfect)
         self.widgets['frame_sync_fix_zero_duration'].setEnabled(is_frame_perfect)
+
+        # VideoTimestamps rounding only applies to videotimestamps mode
+        self.widgets['videotimestamps_rounding'].setEnabled(is_videotimestamps)
 
 class ChaptersTab(QWidget):
     def __init__(self):


### PR DESCRIPTION
… option

Critical fix based on VideoTimestamps documentation:
- Changed from TimeType.START to TimeType.EXACT for accurate frame timing
- TimeType.EXACT gives [current, next[ interval (precise video player behavior)
- TimeType.START was giving ]previous, current] (incorrect for subtitles)

This matches how PyonFX uses VideoTimestamps for professional subtitle timing.

Added RoundingMethod configuration:
- New setting: videotimestamps_rounding (round/floor)
- ROUND: Round half up (default, balanced)
- FLOOR: Always round down (matches Aegisub int() behavior)
- Added UI dropdown in Subtitle Sync settings

Updated functions to pass config:
- get_vfr_timestamps() now accepts config parameter
- time_to_frame_vfr() and frame_to_time_vfr() use config
- Cache key includes rounding method to prevent conflicts

Simplified apply_videotimestamps_sync:
- Removed unused original time->frame conversions
- Apply delay in ms, then snap both start/end to frames
- Uses TimeType.EXACT for precise frame boundaries
- Better logging showing RoundingMethod and TimeType

This should fix the "random off by 1 frame" issues by using the library correctly.