### PR TITLE
Add blank line after [Aegisub Project Garbage] section

### DIFF
--- a/vsg_core/subtitles/metadata_preserver.py
+++ b/vsg_core/subtitles/metadata_preserver.py
@@ -292,6 +292,8 @@ class SubtitleMetadata:
                     new_lines.append(line)
                     for orig_line in self.project_garbage_lines:
                         new_lines.append(orig_line + '\n')
+                    # Add blank line after section (standard ASS format)
+                    new_lines.append('\n')
                     in_project_garbage = True
                     section_replaced = True
                     continue


### PR DESCRIPTION
The ASS format has a blank line between sections. When restoring the [Aegisub Project Garbage] section, we need to also add the blank line after it to match the original file structure.

This ensures the line count matches exactly (1485 lines).