### PR TITLE
Document algorithm constants and magic numbers

### DIFF
--- a/vsg_core/correction/stepping.py
+++ b/vsg_core/correction/stepping.py
@@ -1080,11 +1080,14 @@ class SteppingCorrector:
             segment_end_s = edl[i+1].start_s if i + 1 < len(edl) else pcm_duration_s
             segment_duration_s = segment_end_s - segment_start_s
 
+            # Skip segments under 1 second - too short for reliable audio correlation
             if segment_duration_s < 1.0:
                 self.log(f"    - Skipping segment from {segment_start_s:.2f}s to {segment_end_s:.2f}s: too short ({segment_duration_s:.2f}s)")
                 final_edl.append(current_segment)
                 continue
 
+            # Skip fine-scanning segments under 20 seconds - not worth the computational cost
+            # These short segments are handled with the coarse delay estimate
             if segment_duration_s < 20.0:
                 final_edl.append(current_segment)
                 continue

--- a/vsg_core/subtitles/frame_sync.py
+++ b/vsg_core/subtitles/frame_sync.py
@@ -157,15 +157,16 @@ def get_vfr_timestamps(video_path: str, fps: float, runner, config: dict = None)
         # For now, use FPSTimestamps (lightweight) for CFR videos
         # This just does math, doesn't analyze the video file
 
-        # Convert FPS to fraction (e.g., 23.976 = 24000/1001)
+        # Convert FPS to exact fraction for NTSC drop-frame rates
+        # NTSC standards use fractional rates (N*1000/1001) to avoid color/audio drift
         if abs(fps - 23.976) < 0.001:
-            fps_frac = Fraction(24000, 1001)
+            fps_frac = Fraction(24000, 1001)  # 23.976fps - NTSC film (24fps slowed down)
         elif abs(fps - 29.97) < 0.01:
-            fps_frac = Fraction(30000, 1001)
+            fps_frac = Fraction(30000, 1001)  # 29.97fps - NTSC video (30fps slowed down)
         elif abs(fps - 59.94) < 0.01:
-            fps_frac = Fraction(60000, 1001)
+            fps_frac = Fraction(60000, 1001)  # 59.94fps - NTSC high fps (60fps slowed down)
         else:
-            # Use decimal FPS as fraction
+            # Use decimal FPS as fraction for non-NTSC rates (PAL, web video, etc.)
             fps_frac = Fraction(int(fps * 1000), 1000).limit_denominator(10000)
 
         # Use FPSTimestamps for CFR (constant framerate) - lightweight!


### PR DESCRIPTION
Add explanatory comments for hardcoded thresholds:
- PAL drift detection: 40.9 ms/s rate and formula explanation
- Transition analysis: 50ms tolerance for pattern recognition
- Low match warning: 70% threshold for diagnostics
- Segment duration filters: 1.0s and 20.0s performance thresholds
- NTSC framerates: 23.976, 29.97, 59.94 drop-frame standards

All values are algorithm constants, not intended to be configurable.