### PR TITLE
Fix generated track source path not updating when pasting layouts

### DIFF
--- a/vsg_qt/job_queue_dialog/logic.py
+++ b/vsg_qt/job_queue_dialog/logic.py
@@ -275,6 +275,10 @@ class JobQueueLogic:
             source_key = new_track.get('source')
             if source_key in target_sources:
                 new_track['original_path'] = target_sources[source_key]
+                # CRITICAL FIX: Also update generated_source_path for generated tracks
+                # This ensures the Edit dialog extracts from the correct source file
+                if new_track.get('is_generated'):
+                    new_track['generated_source_path'] = target_sources[source_key]
             new_layout.append(new_track)
         return new_layout
 


### PR DESCRIPTION
CRITICAL BUG FIX:
- When pasting layouts, generated_source_path wasn't being updated
- This caused the Edit dialog to extract from the WRONG source file
- User would see old file's event counts instead of current file's counts
- Now updates generated_source_path along with original_path

This fixes the issue where:
1. Paste layout to different job
2. Right-click generated track → Edit
3. Dialog showed OLD file's styles instead of NEW file's styles