### PR TITLE
Fix missing generated_original_style_list in layout saving + improve …

### DIFF
--- a/vsg_qt/track_widget/logic.py
+++ b/vsg_qt/track_widget/logic.py
@@ -178,6 +178,7 @@ class TrackWidgetLogic:
             "generated_source_path": self.track_data.get('generated_source_path'),
             "generated_filter_mode": self.track_data.get('generated_filter_mode', 'exclude'),
             "generated_filter_styles": self.track_data.get('generated_filter_styles', []),
+            "generated_original_style_list": self.track_data.get('generated_original_style_list', []),
             "generated_verify_only_lines_removed": self.track_data.get('generated_verify_only_lines_removed', True),
         }
 


### PR DESCRIPTION
…error handling

CRITICAL FIX 1: Save generated_original_style_list to layouts
- track_widget get_config() was missing generated_original_style_list
- This field is essential for validation when pasting layouts
- Now properly saved and loaded

CRITICAL FIX 2: Remove failed generated tracks from pipeline
- If generated track processing fails (source not found, verification fails, etc.)
- Track is now removed from pipeline instead of being left in invalid state
- Prevents downstream errors in subtitle/mux steps
- Clear logging shows which tracks were removed and why

Error handling now catches:
- Source track not found
- Source file doesn't exist
- Style filtering failures
- Verification failures
- Any unexpected exceptions

All failures are logged clearly and track is removed safely.