### PR TITLE
Fix generated track verification failure with duplicate timing/text e…

### DIFF
--- a/vsg_core/subtitles/style_filter.py
+++ b/vsg_core/subtitles/style_filter.py
@@ -197,9 +197,10 @@ class StyleFilterEngine:
         """
         issues = []
 
-        # Create a mapping of filtered events by their text/timing signature
+        # Create a mapping of filtered events by their text/timing/style signature
+        # Include style in signature to handle events with same timing/text but different styles
         filtered_map = {
-            (e['start'], e['end'], e['text']): e
+            (e['start'], e['end'], e['style'], e['text']): e
             for e in filtered_events
         }
 
@@ -210,7 +211,8 @@ class StyleFilterEngine:
                 (mode == 'include' and orig_event['style'] not in filter_styles)
             )
 
-            signature = (orig_event['start'], orig_event['end'], orig_event['text'])
+            # Include style in signature to match the filtered_map key format
+            signature = (orig_event['start'], orig_event['end'], orig_event['style'], orig_event['text'])
 
             if should_be_removed:
                 # This event should have been filtered out


### PR DESCRIPTION
…vents

The verification logic was failing when subtitle files contained multiple events with identical timing and text but different styles (common for comment markers at timestamp 0ms).

Root cause: The signature used to verify filtered events only included (start, end, text), causing collisions when multiple events shared these values but had different styles.

Fix: Include 'style' in the event signature to make it unique:
- Changed signature from (start, end, text) to (start, end, style, text)
- Updated both filtered_map creation and lookup to use the same signature

This fixes the false positive "Event was NOT removed as expected" errors that were causing generated tracks to fail validation and crash jobs.