### PR TITLE
Add validation for missing filter styles in generated tracks

### DIFF
--- a/vsg_qt/job_queue_dialog/logic.py
+++ b/vsg_qt/job_queue_dialog/logic.py
@@ -150,6 +150,17 @@ class JobQueueLogic:
                     available_styles = StyleFilterEngine.get_styles_from_file(extracted[0]['path'])
                     available_style_set = set(available_styles.keys())
 
+                    # ADDITIONAL CHECK: Validate that the filter styles actually exist
+                    # This catches cases where style names changed (e.g., "Default" -> "Dialogue")
+                    filter_styles = track.get('generated_filter_styles', [])
+                    if filter_styles:
+                        missing_filter_styles = [s for s in filter_styles if s not in available_style_set]
+                        if missing_filter_styles:
+                            issues.append(
+                                f"'{track_name}': Filter styles not found in target file: "
+                                f"{', '.join(missing_filter_styles)} - Generated track may not filter any events"
+                            )
+
                     # Compare complete style sets
                     original_style_set = set(original_style_list)
 


### PR DESCRIPTION
Adds an additional check when pasting layouts with generated tracks to validate that the specific filter styles (e.g., "Default", "Default-Alt") actually exist in the target file.

This complements the existing baseline style list validation:
- Existing check: Validates complete style list, auto-fixes missing styles
- New check: Validates selected filter styles exist in target file
- Warning: "Filter styles not found: ... - may not filter any events"

This catches cases where fansub groups use different style names across episodes (e.g., "Default" vs "Dialogue"), preventing silent failures where the generated track would filter 0 events at runtime.