### PR TITLE
Fix temp directory collision in generated track validation

### DIFF
--- a/vsg_qt/job_queue_dialog/logic.py
+++ b/vsg_qt/job_queue_dialog/logic.py
@@ -134,10 +134,16 @@ class JobQueueLogic:
             try:
                 # Extract the source subtitle temporarily to check styles
                 import tempfile
+                import time
                 from pathlib import Path
                 from vsg_core.extraction.tracks import extract_tracks
 
-                temp_dir = Path(tempfile.gettempdir()) / f"vsg_gen_validate_{source_key}_{source_id}"
+                # CRITICAL FIX: Include job_id to make temp path unique per episode
+                # Without this, all episodes would share the same temp directory and could
+                # validate against the wrong episode's subtitle file
+                job_id = self.layout_manager.generate_job_id(job['sources'])
+                timestamp = int(time.time() * 1000)  # milliseconds for uniqueness
+                temp_dir = Path(tempfile.gettempdir()) / f"vsg_gen_validate_{job_id}_{source_key}_{source_id}_{timestamp}"
                 temp_dir.mkdir(parents=True, exist_ok=True)
 
                 try:


### PR DESCRIPTION
CRITICAL BUG: The validation temp directory path only used source_key and track_id, causing all episodes to share the same temp directory:
  Episode 1: /tmp/vsg_gen_validate_Source 3_2
  Episode 2: /tmp/vsg_gen_validate_Source 3_2  <- COLLISION!

When validating multiple jobs in batch mode:
1. Episode 1 validates, extracts subtitle to temp dir
2. Episode 2 validates to SAME temp dir, may reuse Episode 1's file
3. Episode 2's layout gets auto-fixed based on Episode 1's subtitle
4. Episode 2 runs with wrong subtitle content from Episode 1

Fix: Include job_id and timestamp in temp path to ensure uniqueness:
  /tmp/vsg_gen_validate_{job_id}_{source_key}_{source_id}_{timestamp}

This ensures each episode validates against its own subtitle file.