### PR TITLE
Remove auto-naming from generated subtitle tracks

### DIFF
--- a/vsg_qt/generated_track_dialog/ui.py
+++ b/vsg_qt/generated_track_dialog/ui.py
@@ -104,14 +104,7 @@ class GeneratedTrackDialog(QDialog):
         name_layout = QHBoxLayout(name_group)
         name_label = QLabel("Name:")
         self.name_edit = QLineEdit()
-
-        # Default name based on source
-        default_name = self.source_track.get('name', 'Subtitles')
-        if default_name:
-            default_name = f"{default_name} (Signs)"
-        else:
-            default_name = "Signs & Songs"
-        self.name_edit.setText(default_name)
+        self.name_edit.setPlaceholderText("Leave empty for no custom name")
 
         name_layout.addWidget(name_label)
         name_layout.addWidget(self.name_edit)
@@ -233,8 +226,6 @@ class GeneratedTrackDialog(QDialog):
             return
 
         track_name = self.name_edit.text().strip()
-        if not track_name:
-            track_name = "Generated Track"
 
         mode = 'exclude' if self.exclude_radio.isChecked() else 'include'
 

--- a/vsg_qt/manual_selection_dialog/ui.py
+++ b/vsg_qt/manual_selection_dialog/ui.py
@@ -355,7 +355,8 @@ class ManualSelectionDialog(QDialog):
         self.final_list.add_track_widget(generated_track)
 
         # Show confirmation
-        self.info_label.setText(f"✅ Generated track '{filter_config['name']}' created successfully.")
+        name_display = f"'{filter_config['name']}' " if filter_config['name'] else ""
+        self.info_label.setText(f"✅ Generated track {name_display}created successfully.")
         self.info_label.setVisible(True)
 
     def _edit_generated_track(self, widget: TrackWidget, item):
@@ -377,7 +378,7 @@ class ManualSelectionDialog(QDialog):
         existing_config = {
             'mode': track_data.get('generated_filter_mode', 'exclude'),
             'styles': track_data.get('generated_filter_styles', []),
-            'name': track_data.get('custom_name', track_data.get('name', 'Generated Track'))
+            'name': track_data.get('custom_name', track_data.get('name', ''))
         }
 
         # Get the source track information
@@ -452,7 +453,8 @@ class ManualSelectionDialog(QDialog):
             widget.logic.refresh_summary()
 
         # Show confirmation
-        self.info_label.setText(f"✅ Generated track '{filter_config['name']}' updated successfully.")
+        name_display = f"'{filter_config['name']}' " if filter_config['name'] else ""
+        self.info_label.setText(f"✅ Generated track {name_display}updated successfully.")
         self.info_label.setVisible(True)
 
     def _launch_style_editor(self, widget: TrackWidget):


### PR DESCRIPTION
- Remove default name generation ("Subtitles (Signs)", "Signs & Songs")
- Remove "Generated Track" fallback when name field is empty
- Allow tracks to have no custom name unless explicitly set by user
- Update confirmation messages to handle empty names gracefully

Fixes issue where users had to delete auto-generated names in multiple places