### PR TITLE
Fix FFMS2 index loading - use indexfile parameter instead of Index()

### DIFF
--- a/vsg_core/subtitles/frame_matching.py
+++ b/vsg_core/subtitles/frame_matching.py
@@ -75,8 +75,9 @@ class VideoReader:
             if index_path.exists():
                 runner._log_message(f"[FrameMatch] ✓ Reusing cached FFMS2 index!")
                 runner._log_message(f"[FrameMatch] Loading index from: {index_path.name}")
-                # Load existing index
-                index = ffms2.Index(str(index_path))
+                # Load video source with existing index file
+                # Note: FFMS2 doesn't have Index(filepath) - use indexfile parameter instead
+                self.source = ffms2.VideoSource(str(video_path), indexfile=str(index_path))
             else:
                 runner._log_message(f"[FrameMatch] Creating FFMS2 index (one-time cost)...")
                 runner._log_message(f"[FrameMatch] This may take 1-2 minutes, but enables instant frame access...")
@@ -88,8 +89,9 @@ class VideoReader:
                 index.write(str(index_path))
                 runner._log_message(f"[FrameMatch] ✓ Index created and saved to: {index_path.name}")
 
-            # Create video source from index
-            self.source = ffms2.VideoSource(str(video_path), index=index)
+                # Create video source from the newly created index object
+                self.source = ffms2.VideoSource(str(video_path), index=index)
+
             self.use_ffms2 = True
 
             # Get video properties


### PR DESCRIPTION
The FFMS2 Python bindings don't support loading an Index object from a file. Instead, when reusing a cached index, pass the indexfile parameter directly to VideoSource.

Changes:
- Line 80: Use VideoSource(path, indexfile=index_path) when loading cached index
- Line 93: Use VideoSource(path, index=index) when creating new index

This fixes the error:
"TypeError: expected LP_FFMS_Index instance instead of str"