### PR TITLE
Fix VapourSynth core initialization - vs.core is not callable

### DIFF
--- a/vsg_core/subtitles/frame_matching.py
+++ b/vsg_core/subtitles/frame_matching.py
@@ -147,8 +147,8 @@ class VideoReader:
 
             self.runner._log_message("[FrameMatch] Attempting VapourSynth with FFMS2 plugin...")
 
-            # Create thread-local core
-            core = vs.core.core()
+            # Get VapourSynth core instance
+            core = vs.core
 
             # Check if ffms2 plugin is available
             if not hasattr(core, 'ffms2'):


### PR DESCRIPTION
Fixed bug where vs.core.core() was called instead of vs.core. vs.core is already the Core object, not a function.

This was causing:
'vapoursynth.Core' object is not callable

Changed:
- core = vs.core.core()  # WRONG
+ core = vs.core         # CORRECT