### PR TITLE
Fix VapourSynth frame extraction - use correct API for plane data

### DIFF
--- a/vsg_core/subtitles/frame_matching.py
+++ b/vsg_core/subtitles/frame_matching.py
@@ -237,10 +237,10 @@ class VideoReader:
             height = frame.height
 
             # VapourSynth frames are planar (separate R, G, B planes)
-            # Use get_read_array() to get properly shaped numpy arrays
-            r_plane = np.asarray(frame.get_read_array(0))
-            g_plane = np.asarray(frame.get_read_array(1))
-            b_plane = np.asarray(frame.get_read_array(2))
+            # frame[plane] returns memoryview, convert to numpy with proper shape
+            r_plane = np.frombuffer(frame[0], dtype=np.uint8).reshape(height, width)
+            g_plane = np.frombuffer(frame[1], dtype=np.uint8).reshape(height, width)
+            b_plane = np.frombuffer(frame[2], dtype=np.uint8).reshape(height, width)
 
             # Stack planes into RGB image (height, width, 3)
             rgb_array = np.stack([r_plane, g_plane, b_plane], axis=-1)


### PR DESCRIPTION
Fixed 'VideoFrame' object has no attribute 'get_read_array' error.

The correct VapourSynth API for reading frame data is:
- frame[plane] returns a memoryview of the plane data
- Use np.frombuffer() to convert to numpy array
- Reshape to (height, width) for each plane

Changes:
- r_plane = np.frombuffer(frame[0], dtype=np.uint8).reshape(height, width)
- g_plane = np.frombuffer(frame[1], dtype=np.uint8).reshape(height, width)
- b_plane = np.frombuffer(frame[2], dtype=np.uint8).reshape(height, width)
- Stack with np.stack() to create RGB image

This matches the standard VapourSynth frame access pattern.