### PR TITLE
Convert VapourSynth clip to RGB24 format for frame extraction

### DIFF
--- a/vsg_core/subtitles/frame_matching.py
+++ b/vsg_core/subtitles/frame_matching.py
@@ -168,10 +168,14 @@ class VideoReader:
             else:
                 self.runner._log_message(f"[FrameMatch] Creating new index (this may take 1-2 minutes)...")
 
-            self.vs_clip = core.ffms2.Source(
+            clip = core.ffms2.Source(
                 source=str(self.video_path),
                 cachefile=str(index_path)
             )
+
+            # Convert to RGB24 for easier frame extraction
+            # FFMS2 outputs YUV by default, we need RGB for PIL
+            self.vs_clip = core.resize.Bicubic(clip, format=vs.RGB24, matrix_in_s="709")
 
             # Get video properties
             self.fps = self.vs_clip.fps_num / self.vs_clip.fps_den


### PR DESCRIPTION
Fixed 'cannot reshape array of size 4147200 into shape (1080,1920)' error.

The issue was that FFMS2 outputs YUV format by default, where chroma planes are half-resolution (YUV420). This caused reshape errors when trying to treat planes as full-resolution RGB.

Solution:
- Use core.resize.Bicubic() to convert clip to RGB24 format
- RGB24 has 3 full-resolution planes (R, G, B) of equal size
- Now frame[0], frame[1], frame[2] are all full (height, width) arrays
- matrix_in_s="709" uses Rec.709 color matrix (standard for HD video)

This adds minimal overhead as VapourSynth handles conversion efficiently.