### PR TITLE
Fix VapourSynth frame extraction - use array protocol with np.asarray()

### DIFF
--- a/vsg_core/subtitles/frame_matching.py
+++ b/vsg_core/subtitles/frame_matching.py
@@ -236,21 +236,9 @@ class VideoReader:
             # Get frame (instant - uses FFMS2 index!)
             frame = self.vs_clip.get_frame(frame_num)
 
-            # Get frame dimensions and stride
-            width = frame.width
-            height = frame.height
-
-            # VapourSynth frames have stride (row padding for alignment)
-            # We need to handle this properly
-            plane_data = frame.get_read_ptr(0)  # Get pointer to Y plane
-            stride = frame.get_stride(0)  # Get stride (bytes per row including padding)
-
-            # Create array from pointer with stride
-            arr = np.frombuffer(plane_data, dtype=np.uint8, count=stride * height)
-            arr = arr.reshape(height, stride)
-
-            # Extract only the actual image data (remove padding)
-            y_plane = arr[:, :width]
+            # VapourSynth frames support the array protocol
+            # frame[0] is the Y (luma) plane, np.asarray handles stride automatically
+            y_plane = np.asarray(frame[0])
 
             # Convert to PIL Image (grayscale mode 'L')
             return Image.fromarray(y_plane, 'L')


### PR DESCRIPTION
Fixed 'buffer is smaller than requested size' error.

The issue was trying to manually handle stride with get_read_ptr() and np.frombuffer(), which doesn't work correctly because get_read_ptr() returns a raw pointer without size information.

Solution:
Use VapourSynth's array protocol which handles stride automatically:
  y_plane = np.asarray(frame[0])

This is the standard, documented way to extract VapourSynth frame data to numpy arrays. The array protocol handles:
- Stride (row padding)
- Memory layout
- Data type conversion

Much simpler and more reliable than manual pointer manipulation.