### PR TITLE
Fix dual-videotimestamps mode: rounding config and frame number units

### DIFF
--- a/vsg_core/subtitles/frame_sync.py
+++ b/vsg_core/subtitles/frame_sync.py
@@ -170,7 +170,8 @@ def get_vfr_timestamps(video_path: str, fps: float, runner, config: dict = None)
             fps_frac = Fraction(int(fps * 1000), 1000).limit_denominator(10000)
 
         # Use FPSTimestamps for CFR (constant framerate) - lightweight!
-        time_scale = Fraction(1000)  # milliseconds
+        # time_scale = 1 means we work in seconds (not milliseconds)
+        time_scale = Fraction(1)
         vts = FPSTimestamps(rounding_method, time_scale, fps_frac)
 
         runner._log_message(f"[VideoTimestamps] Using FPSTimestamps for CFR video at {fps:.3f} fps")
@@ -215,8 +216,9 @@ def frame_to_time_vfr(frame_num: int, video_path: str, fps: float, runner, confi
         # Get exact timestamp for this frame
         # Use EXACT time (precise frame display window) - NOT START!
         # EXACT gives [current, next[ which matches video player behavior
-        time_ms = vts.frame_to_time(frame_num, TimeType.EXACT)
-        return int(time_ms)
+        # time_scale = 1 (seconds), so we need to convert seconds to milliseconds
+        time_seconds = vts.frame_to_time(frame_num, TimeType.EXACT)
+        return int(time_seconds * 1000)
 
     except Exception as e:
         runner._log_message(f"[VideoTimestamps] WARNING: frame_to_time_vfr failed: {e}")
@@ -247,8 +249,9 @@ def time_to_frame_vfr(time_ms: float, video_path: str, fps: float, runner, confi
         if vts is None:
             return None
 
-        # Convert time_ms to Fraction (required by VideoTimestamps)
-        time_frac = Fraction(int(time_ms), 1)
+        # Convert time_ms to seconds as Fraction (required by VideoTimestamps)
+        # time_scale = 1 (seconds), so we need to convert ms to seconds
+        time_frac = Fraction(int(time_ms), 1000)
 
         # Convert time to frame using EXACT (precise frame display window)
         # EXACT gives [current, next[ which matches video player behavior

--- a/vsg_qt/options_dialog/tabs.py
+++ b/vsg_qt/options_dialog/tabs.py
@@ -1252,7 +1252,7 @@ class SubtitleSyncTab(QWidget):
         """Show/hide FPS and frame timing settings based on sync mode."""
         is_frame_perfect = (text == 'frame-perfect')
         is_frame_snapped = (text == 'frame-snapped')
-        is_videotimestamps = (text == 'videotimestamps')
+        is_videotimestamps = (text == 'videotimestamps' or text == 'dual-videotimestamps')
         is_frame_matched = (text == 'frame-matched')
 
         # FPS setting is used by frame-perfect, frame-snapped, and videotimestamps (not frame-matched)


### PR DESCRIPTION
Two fixes for dual-videotimestamps mode:

1. Enable videotimestamps_rounding dropdown in GUI
   - Updated _update_fps_visibility() to enable rounding selector
   - Now allows choosing FLOOR/ROUND for dual-videotimestamps mode
   - Fixes off-by-1-frame issues with ROUND rounding

2. Fix 1000x unit conversion bug in frame numbers
   - Changed time_scale from Fraction(1000) to Fraction(1)
   - VideoTimestamps now works in seconds (base unit)
   - Convert ms→seconds on input: Fraction(time_ms, 1000)
   - Convert seconds→ms on output: time_seconds * 1000
   - Frame numbers now display correctly (~5418 instead of 5418581)

These fixes allow users to control rounding behavior and see accurate frame numbers in logs while maintaining correct subtitle timing.