### PR TITLE
Fix VideoTimestamps API usage with correct parameters and units

### DIFF
--- a/vsg_core/subtitles/frame_sync.py
+++ b/vsg_core/subtitles/frame_sync.py
@@ -170,9 +170,10 @@ def get_vfr_timestamps(video_path: str, fps: float, runner, config: dict = None)
             fps_frac = Fraction(int(fps * 1000), 1000).limit_denominator(10000)
 
         # Use FPSTimestamps for CFR (constant framerate) - lightweight!
-        # time_scale = 1 means we work in seconds (not milliseconds)
-        time_scale = Fraction(1)
-        vts = FPSTimestamps(rounding_method, time_scale, fps_frac)
+        # time_scale: Unit of time (in seconds) in which frame PTS are represented
+        # Fraction(1000) = milliseconds (1/1000 second units)
+        time_scale = Fraction(1000)
+        vts = FPSTimestamps(rounding_method, time_scale, fps_frac, Fraction(0))
 
         runner._log_message(f"[VideoTimestamps] Using FPSTimestamps for CFR video at {fps:.3f} fps")
         runner._log_message(f"[VideoTimestamps] RoundingMethod: {rounding_str}")
@@ -216,9 +217,9 @@ def frame_to_time_vfr(frame_num: int, video_path: str, fps: float, runner, confi
         # Get exact timestamp for this frame
         # Use EXACT time (precise frame display window) - NOT START!
         # EXACT gives [current, next[ which matches video player behavior
-        # time_scale = 1 (seconds), so we need to convert seconds to milliseconds
-        time_seconds = vts.frame_to_time(frame_num, TimeType.EXACT)
-        return int(time_seconds * 1000)
+        # Use output_unit=3 to get time in milliseconds directly
+        time_ms = vts.frame_to_time(frame_num, TimeType.EXACT, output_unit=3)
+        return time_ms
 
     except Exception as e:
         runner._log_message(f"[VideoTimestamps] WARNING: frame_to_time_vfr failed: {e}")
@@ -249,13 +250,10 @@ def time_to_frame_vfr(time_ms: float, video_path: str, fps: float, runner, confi
         if vts is None:
             return None
 
-        # Convert time_ms to seconds as Fraction (required by VideoTimestamps)
-        # time_scale = 1 (seconds), so we need to convert ms to seconds
-        time_frac = Fraction(int(time_ms), 1000)
-
         # Convert time to frame using EXACT (precise frame display window)
         # EXACT gives [current, next[ which matches video player behavior
-        frame_num = vts.time_to_frame(time_frac, TimeType.EXACT)
+        # Pass time_ms as int with input_unit=3 (milliseconds)
+        frame_num = vts.time_to_frame(int(time_ms), TimeType.EXACT, input_unit=3)
         return frame_num
 
     except Exception as e:


### PR DESCRIPTION
Corrected the VideoTimestamps library usage based on official documentation:

1. FPSTimestamps constructor:
   - Restored time_scale to Fraction(1000) for millisecond units
   - Added missing 4th parameter: Fraction(0) for first_timestamps offset
   - time_scale defines internal PTS representation, not I/O units

2. time_to_frame_vfr():
   - Use input_unit=3 to pass time in milliseconds directly
   - Removes unnecessary Fraction conversion overhead
   - Cleaner API usage: vts.time_to_frame(int(time_ms), TimeType.EXACT, input_unit=3)

3. frame_to_time_vfr():
   - Use output_unit=3 to receive time in milliseconds directly
   - Returns int instead of Fraction, no conversion needed
   - Cleaner API usage: vts.frame_to_time(frame_num, TimeType.EXACT, output_unit=3)

This fixes the massive timestamp discrepancies (292-975ms) that were breaking subtitle sync in both dual-videotimestamps and videotimestamps modes.

References:
- https://moi15moi.github.io/VideoTimestamps/
- https://moi15moi.github.io/VideoTimestamps/reference/fps_timestamps/