### PR TITLE
Fix dual-videotimestamps to use frame-to-frame mapping

### DIFF
--- a/vsg_core/subtitles/frame_sync.py
+++ b/vsg_core/subtitles/frame_sync.py
@@ -503,11 +503,23 @@ def apply_dual_videotimestamps_sync(
         if original_duration <= 0:
             continue
 
-        # === STEP 1: Add delay to original subtitle time (NOT rounded source timestamp!) ===
-        # This preserves the original timing relationship without introducing rounding errors
-        adjusted_timestamp = original_start + delay_ms
+        # === STEP 1: Snap to exact frame in SOURCE video first ===
+        # This ensures we start from a frame boundary in the source video
+        source_frame = time_to_frame_vfr(original_start, source_video, source_fps, runner, config)
+        if source_frame is None:
+            runner._log_message(f"[Dual VideoTimestamps] WARNING: Failed to get source frame for time {original_start}ms")
+            continue
 
-        # === STEP 2: Snap to exact frame in TARGET video using VideoTimestamps ===
+        source_timestamp_exact = frame_to_time_vfr(source_frame, source_video, source_fps, runner, config)
+        if source_timestamp_exact is None:
+            runner._log_message(f"[Dual VideoTimestamps] WARNING: Failed to get source timestamp for frame {source_frame}")
+            continue
+
+        # === STEP 2: Add delay to the exact source frame timestamp ===
+        # This preserves frame-to-frame mapping without rounding errors
+        adjusted_timestamp = source_timestamp_exact + delay_ms
+
+        # === STEP 3: Snap to exact frame in TARGET video using VideoTimestamps ===
         target_frame = time_to_frame_vfr(adjusted_timestamp, target_video, target_fps, runner, config)
         if target_frame is None:
             runner._log_message(f"[Dual VideoTimestamps] WARNING: Failed to get target frame for time {adjusted_timestamp}ms")
@@ -518,15 +530,11 @@ def apply_dual_videotimestamps_sync(
             runner._log_message(f"[Dual VideoTimestamps] WARNING: Failed to get target timestamp for frame {target_frame}")
             continue
 
-        # === STEP 3: Update subtitle with frame-accurate timestamp ===
+        # === STEP 4: Update subtitle with frame-accurate timestamp ===
         event.start = target_timestamp_exact
         event.end = target_timestamp_exact + original_duration
 
         # Track statistics
-        # For verification, also check what frame this was in the source
-        source_frame = time_to_frame_vfr(original_start, source_video, source_fps, runner, config)
-        source_timestamp_exact = frame_to_time_vfr(source_frame, source_video, source_fps, runner, config) if source_frame is not None else None
-
         # Compare adjusted_timestamp (what we asked for) vs target_timestamp_exact (what we got)
         discrepancy = abs(adjusted_timestamp - target_timestamp_exact)
         timestamp_discrepancies.append(discrepancy)
@@ -537,11 +545,10 @@ def apply_dual_videotimestamps_sync(
         # Log first few matches for verification
         if matched_count <= 3:
             runner._log_message(f"[Dual VideoTimestamps] Line {matched_count}:")
-            runner._log_message(f"  Original: {original_start}ms → Source frame {source_frame}")
-            runner._log_message(f"  Adjusted: {original_start}ms + {delay_ms}ms = {adjusted_timestamp}ms")
-            runner._log_message(f"  Target: frame {target_frame} at {target_timestamp_exact}ms")
-            if source_timestamp_exact:
-                runner._log_message(f"  Source frame exact timestamp: {source_timestamp_exact}ms (for comparison)")
+            runner._log_message(f"  Original subtitle time: {original_start}ms")
+            runner._log_message(f"  Source frame {source_frame} exact timestamp: {source_timestamp_exact}ms")
+            runner._log_message(f"  After adding delay: {source_timestamp_exact}ms + {delay_ms:.3f}ms = {adjusted_timestamp:.3f}ms")
+            runner._log_message(f"  Target frame {target_frame} exact timestamp: {target_timestamp_exact}ms")
 
 
     # Save modified subtitle


### PR DESCRIPTION
- Step 1: Snap original subtitle time to exact source video frame
- Step 2: Add delay to source frame's exact timestamp
- Step 3: Snap result to exact target video frame
- Ensures true frame-to-frame mapping instead of time-to-frame
- Fixes 1-frame offset caused by subtitle timing not being exactly on source frame boundary