### PR TITLE
Fix subtitle sync: implement single global frame-corrected delay

### DIFF
--- a/vsg_core/models/jobs.py
+++ b/vsg_core/models/jobs.py
@@ -14,7 +14,9 @@ class JobSpec:
 @dataclass(frozen=True)
 class Delays:
     source_delays_ms: Dict[str, int] = field(default_factory=dict)
+    raw_source_delays_ms: Dict[str, float] = field(default_factory=dict)  # Unrounded delays for VideoTimestamps precision
     global_shift_ms: int = 0
+    raw_global_shift_ms: float = 0.0  # Unrounded global shift for VideoTimestamps precision
 
 @dataclass
 class PlanItem:


### PR DESCRIPTION
PROBLEM:
Previous implementation caused random ±1-4 frame errors by independently snapping each subtitle event to frames, corrupting relative timing between subtitles.

SOLUTION:
Implement correct subtitle sync algorithm:
1. Use video-timestamps ONLY to compute a single frame-corrected delay
2. Apply that ONE delay to ALL subtitle events (preserves relative timing)
3. No per-event frame snapping (eliminates rounding inconsistencies)

CHANGES:
- Add raw_source_delays_ms and raw_global_shift_ms fields to Delays model (preserves float precision from audio correlation, prevents triple-rounding)

- Update analysis_step.py to track both rounded (for mkvmerge) and raw (for VideoTimestamps) delays throughout the pipeline

- Add compute_frame_corrected_delay() function in frame_sync.py
  - Uses anchor subtitle (first dialogue line) to calculate frame correction
  - Snaps anchor to source frame, adds delay, snaps to target frame
  - Returns single corrected delay for all events

- Rewrite apply_dual_videotimestamps_sync() to use anchor-based approach
  - Calls compute_frame_corrected_delay() once
  - Applies result to all events uniformly
  - No per-event frame operations

- Rewrite apply_videotimestamps_sync() to use anchor-based approach
  - Single-video variant of frame correction algorithm
  - Same benefits: no per-event snapping

- Update subtitles_step.py to pass raw delays (not rounded) to both videotimestamps modes for maximum precision

RESULT:
Subtitles now maintain perfect relative timing while being frame-accurate to the target video. ASS/SRT format handles final centisecond quantization.