### PR TITLE
Fix hybrid verification bugs and abort behavior

### DIFF
--- a/vsg_core/orchestrator/steps/subtitles_step.py
+++ b/vsg_core/orchestrator/steps/subtitles_step.py
@@ -308,8 +308,15 @@ class SubtitlesStep:
                                     runner._log_message("------------------------------------------")
                                     # Mark that timestamps have been adjusted
                                     item.frame_adjusted = True
+                                elif frame_sync_report and 'error' in frame_sync_report:
+                                    # Sync function returned error - this is a fatal error (abort mode)
+                                    error_msg = frame_sync_report['error']
+                                    runner._log_message(f"[Duration Align] ERROR: Sync failed for track {item.track.id}: {error_msg}")
+                                    raise RuntimeError(f"Duration-align sync failed for track {item.track.id}: {error_msg}")
                                 else:
-                                    runner._log_message(f"[Duration Align] WARNING: Sync failed for track {item.track.id}")
+                                    # No report returned at all - unexpected
+                                    runner._log_message(f"[Duration Align] ERROR: No sync report returned for track {item.track.id}")
+                                    raise RuntimeError(f"Duration-align sync failed for track {item.track.id}: No report returned")
                             else:
                                 runner._log_message(f"[Duration Align] ERROR: Missing source or target video")
                                 runner._log_message(f"[Duration Align] Source: {source_video}, Target: {target_video}")


### PR DESCRIPTION
## Issues Fixed:

1. **VideoReader import error**: Changed `compute_perceptual_hash` to correct function name `compute_frame_hash`
2. **Wrong time units**: Fixed passing seconds instead of milliseconds to `get_frame_at_time()`
3. **Hash comparison**: Fixed to use ImageHash subtraction operator (returns hamming distance)
4. **Abort didn't stop job**: Added RuntimeError raise when sync fails so job actually fails

## Changes:

**vsg_core/subtitles/frame_sync.py**:
- Import correct function: `compute_frame_hash` (not `compute_perceptual_hash`)
- Convert frame times to milliseconds before passing to `get_frame_at_time(int(ms))`
- Use `source_hash - target_hash` for hamming distance (ImageHash operator)
- Add None checks for hash computation failures

**vsg_core/orchestrator/steps/subtitles_step.py**:
- Check if `frame_sync_report` contains 'error' key
- Raise RuntimeError with detailed message when error present
- This properly fails the job for batch processing
- Error propagates up to orchestrator which marks job as failed

## Result:

- Hybrid verification will now actually work (was failing on import)
- Abort mode will now actually abort (raises exception)
- Better error messages for debugging