### PR TITLE
Fix frame-accuracy bugs in correlation-frame-snap mode

### DIFF
--- a/vsg_core/subtitles/frame_matching.py
+++ b/vsg_core/subtitles/frame_matching.py
@@ -227,8 +227,11 @@ class VideoReader:
         try:
             import numpy as np
 
-            # Convert time to frame number
-            frame_num = int((time_ms / 1000.0) * self.fps)
+            # Convert time to frame number using FLOOR with epsilon protection
+            # This ensures stable, deterministic frame selection without FP drift issues
+            frame_duration_ms = 1000.0 / self.fps
+            epsilon = 1e-6  # Protect against FP errors (e.g., 1000.9999 → frame 24, not 23)
+            frame_num = int((time_ms + epsilon) / frame_duration_ms)
 
             # Clamp to valid range
             frame_num = max(0, min(frame_num, len(self.vs_clip) - 1))
@@ -250,8 +253,10 @@ class VideoReader:
     def _get_frame_ffms2(self, time_ms: int) -> Optional[Image.Image]:
         """Extract frame using FFMS2 (instant indexed seeking)."""
         try:
-            # Convert time to frame number
-            frame_num = int((time_ms / 1000.0) * self.fps)
+            # Convert time to frame number using FLOOR with epsilon protection
+            frame_duration_ms = 1000.0 / self.fps
+            epsilon = 1e-6  # Protect against FP errors
+            frame_num = int((time_ms + epsilon) / frame_duration_ms)
 
             # Clamp to valid range
             frame_num = max(0, min(frame_num, self.source.properties.NumFrames - 1))


### PR DESCRIPTION
This fixes exactly 3 bugs causing ±1 frame errors:

BUG #1: Unstable time→frame conversion
- VideoReader used int((time_ms / 1000.0) * fps) without epsilon
- Floating point drift caused wrong frame selection
- Example: 1000.9999 → frame 23 instead of 24
- FIX: Added epsilon protection (1e-6) to both VapourSynth and FFMS2

BUG #2: Incorrect frame snap calculation
- Code treated delta as "add N frames to offset"
- Should be "correct to frame N boundary"
- Example: checkpoint=10000ms, correlation=-42.667ms, delta=0
  - WRONG: offset = -42.667 + (0 * 41.708) = -42.667ms (not frame-aligned!)
  - CORRECT: base_frame=238, target_frame=238+0=238, offset=-73.496ms
- FIX: Use actual frame boundary math:
  - base_frame = time_to_frame_start(checkpoint + correlation)
  - target_frame = base_frame + delta
  - offset = frame_to_time_start(target_frame) - checkpoint

BUG #3: Middle-of-frame timing contamination
- Existing time_to_frame_middle() uses round(time/dur - 0.5)
- The -0.5 offset causes unstable rounding with FP drift
- frame_to_time_middle() adds +0.5 frame offset (wrong for sync)
- FIX: Added new time_to_frame_start() and frame_to_time_start()
  - Use FLOOR with epsilon for stability
  - Use frame START (N * duration), not middle
  - Only for correlation-frame-snap mode

Changes:
- frame_sync.py:
  - Added time_to_frame_start() - FLOOR with epsilon protection
  - Added frame_to_time_start() - frame START timing
  - Fixed verify_correlation_with_frame_snap() offset calculation
  - Uses actual frame boundaries instead of delta arithmetic
- frame_matching.py:
  - Fixed VideoReader._get_frame_vapoursynth() time conversion
  - Fixed VideoReader._get_frame_ffms2() time conversion
  - Both now use epsilon-protected FLOOR

Result: Frame-accurate subtitle sync with no early/late frames.