### PR TITLE
Add correlation-frame-snap subtitle sync mode

### DIFF
--- a/vsg_core/config.py
+++ b/vsg_core/config.py
@@ -60,6 +60,13 @@ class AppConfig:
             'duration_align_verify_checkpoints': 3,  # Number of checkpoints to verify (1 or 3)
             'duration_align_skip_validation_generated_tracks': True,  # Skip validation for generated tracks (default: True)
 
+            # --- Correlation + Frame Snap Settings ---
+            'correlation_snap_fallback_mode': 'snap-to-frame',  # What to do if verification fails: 'snap-to-frame', 'use-raw', 'abort'
+            'correlation_snap_hash_algorithm': 'dhash',  # Hash algorithm: 'dhash', 'phash', 'average_hash'
+            'correlation_snap_hash_size': 8,  # Hash size for perceptual hashing
+            'correlation_snap_hash_threshold': 5,  # Max hamming distance for frame match
+            'correlation_snap_adjacent_frames': 3,  # Number of adjacent frames to check at each checkpoint
+
             # --- Frame-Matched Sync Settings ---
             'frame_match_search_window_sec': 1,  # Reduced to 1 sec with smart delay centering + hash caching
             'frame_match_search_window_frames': 5,  # NEW: Search ±N frames (overrides _sec if > 0)

--- a/vsg_core/orchestrator/steps/subtitles_step.py
+++ b/vsg_core/orchestrator/steps/subtitles_step.py
@@ -17,7 +17,7 @@ from vsg_core.subtitles.ocr import run_ocr
 from vsg_core.subtitles.cleanup import run_cleanup
 from vsg_core.subtitles.timing import fix_subtitle_timing
 from vsg_core.subtitles.stepping_adjust import apply_stepping_to_subtitles
-from vsg_core.subtitles.frame_sync import apply_frame_perfect_sync, apply_videotimestamps_sync, apply_frame_snapped_sync, apply_dual_videotimestamps_sync, apply_raw_delay_sync, apply_duration_align_sync, detect_video_fps
+from vsg_core.subtitles.frame_sync import apply_frame_perfect_sync, apply_videotimestamps_sync, apply_frame_snapped_sync, apply_dual_videotimestamps_sync, apply_raw_delay_sync, apply_duration_align_sync, apply_correlation_frame_snap_sync, detect_video_fps
 from vsg_core.subtitles.frame_matching import apply_frame_matched_sync
 
 class SubtitlesStep:
@@ -187,7 +187,7 @@ class SubtitlesStep:
             if item.extracted_path and not item.stepping_adjusted:
                 subtitle_sync_mode = ctx.settings_dict.get('subtitle_sync_mode', 'time-based')
 
-                if subtitle_sync_mode in ['frame-perfect', 'videotimestamps', 'frame-snapped', 'frame-matched', 'dual-videotimestamps', 'raw-delay', 'duration-align']:
+                if subtitle_sync_mode in ['frame-perfect', 'videotimestamps', 'frame-snapped', 'frame-matched', 'dual-videotimestamps', 'raw-delay', 'duration-align', 'correlation-frame-snap']:
                     # Check if this subtitle format supports frame-perfect sync
                     ext = item.extracted_path.suffix.lower()
                     supported_formats = ['.ass', '.ssa', '.srt', '.vtt']
@@ -322,6 +322,66 @@ class SubtitlesStep:
                                 runner._log_message(f"[Duration Align] Source: {source_video}, Target: {target_video}")
 
                             # Skip the delay-based sync logic for duration-align mode
+                            continue
+
+                        # Correlation + Frame Snap mode: Use correlation as authoritative, refined to frame boundaries
+                        if subtitle_sync_mode == 'correlation-frame-snap':
+                            # Requires source and target videos + correlation delay
+                            source_key = item.sync_to if item.track.source == 'External' else item.track.source
+                            source_video = ctx.sources.get(source_key)
+                            target_video = source1_file
+
+                            # CRITICAL: Get the TOTAL delay (which ALREADY includes global_shift)
+                            # raw_source_delays_ms has global_shift baked in from analysis step
+                            total_delay_with_global_ms = 0.0
+                            if ctx.delays and source_key in ctx.delays.raw_source_delays_ms:
+                                total_delay_with_global_ms = ctx.delays.raw_source_delays_ms[source_key]
+                                runner._log_message(f"[Correlation+FrameSnap] Total delay (with global): {total_delay_with_global_ms:+.3f}ms from {source_key}")
+
+                            # Get raw global shift separately (for the function to subtract and get pure correlation)
+                            raw_global_shift_ms = 0.0
+                            if ctx.delays:
+                                raw_global_shift_ms = ctx.delays.raw_global_shift_ms
+                                runner._log_message(f"[Correlation+FrameSnap] Global shift: {raw_global_shift_ms:+.3f}ms")
+
+                            if source_video and target_video:
+                                runner._log_message(f"[Correlation+FrameSnap] Applying to track {item.track.id} ({item.track.props.name or 'Unnamed'})")
+                                runner._log_message(f"[Correlation+FrameSnap] Source video: {Path(source_video).name}")
+                                runner._log_message(f"[Correlation+FrameSnap] Target video: {Path(target_video).name}")
+
+                                frame_sync_report = apply_correlation_frame_snap_sync(
+                                    str(item.extracted_path),
+                                    str(source_video),
+                                    str(target_video),
+                                    total_delay_with_global_ms,  # ALREADY includes global_shift
+                                    raw_global_shift_ms,          # Passed separately for pure correlation calculation
+                                    runner,
+                                    ctx.settings_dict
+                                )
+
+                                if frame_sync_report and frame_sync_report.get('success'):
+                                    runner._log_message(f"--- Correlation+FrameSnap Sync Report ---")
+                                    for key, value in frame_sync_report.items():
+                                        if key != 'verification':  # Skip nested verification dict
+                                            runner._log_message(f"  - {key.replace('_', ' ').title()}: {value}")
+                                    runner._log_message("------------------------------------------")
+                                    # Mark that timestamps have been adjusted
+                                    item.frame_adjusted = True
+                                elif frame_sync_report and 'error' in frame_sync_report:
+                                    # Sync function returned error
+                                    error_msg = frame_sync_report['error']
+                                    runner._log_message(f"[Correlation+FrameSnap] ERROR: Sync failed for track {item.track.id}: {error_msg}")
+                                    raise RuntimeError(f"Correlation+FrameSnap sync failed for track {item.track.id}: {error_msg}")
+                                else:
+                                    # No report or unexpected result
+                                    runner._log_message(f"[Correlation+FrameSnap] ERROR: No sync report returned for track {item.track.id}")
+                                    raise RuntimeError(f"Correlation+FrameSnap sync failed for track {item.track.id}: No report returned")
+                            else:
+                                runner._log_message(f"[Correlation+FrameSnap] ERROR: Missing source or target video")
+                                runner._log_message(f"[Correlation+FrameSnap] Source: {source_video}, Target: {target_video}")
+                                raise RuntimeError(f"Correlation+FrameSnap sync failed: missing source/target video")
+
+                            # Skip the delay-based sync logic for correlation-frame-snap mode
                             continue
 
                         # Dual-VideoTimestamps mode: Frame-accurate mapping using both videos' timestamps


### PR DESCRIPTION
This new mode fixes the math errors from the failed branch by:
- Using raw_source_delays_ms (which ALREADY includes global_shift)
- Subtracting global_shift to get pure correlation for frame verification
- Applying frame verification against ORIGINAL videos (before global shift)
- Adding frame_correction to total_delay (not double-applying global_shift)
- Using floor rounding for final ASS timestamps (user preference)

Key changes:
- Add time_to_frame_floor/frame_to_time_floor (stable, deterministic)
- Add verify_correlation_with_frame_snap with correct target_time calculation
- Add apply_correlation_frame_snap_sync main sync function
- Integrate into subtitles_step.py with correct delay value handling
- Add UI options in Options dialog (fallback mode, hash settings)
- Add config defaults for all correlation_snap settings

The critical fix: raw_source_delays_ms already has global_shift baked in (from analysis_step.py lines 551-552), so the verification must use pure_correlation = total_delay - global_shift, and the final offset is simply total_delay + frame_correction (NOT + global_shift again).