### PR TITLE
Add configurable search range and window radius for encodes

### DIFF
--- a/vsg_core/config.py
+++ b/vsg_core/config.py
@@ -64,8 +64,10 @@ class AppConfig:
             'correlation_snap_fallback_mode': 'snap-to-frame',  # What to do if verification fails: 'snap-to-frame', 'use-raw', 'abort'
             'correlation_snap_hash_algorithm': 'dhash',  # Hash algorithm: 'dhash', 'phash', 'average_hash'
             'correlation_snap_hash_size': 8,  # Hash size for perceptual hashing
-            'correlation_snap_hash_threshold': 5,  # Max hamming distance for frame match
-            'correlation_snap_adjacent_frames': 3,  # Number of adjacent frames to check at each checkpoint
+            'correlation_snap_hash_threshold': 5,  # Max hamming distance for frame match (increase for encodes)
+            'correlation_snap_window_radius': 3,  # Frames before/after center for sliding window (3 = 7 frame window)
+            'correlation_snap_search_range': 5,  # Search ±N frames around correlation prediction (increase for encodes)
+            'correlation_snap_use_scene_changes': True,  # Use PySceneDetect to find anchor points
 
             # --- Frame-Matched Sync Settings ---
             'frame_match_search_window_sec': 1,  # Reduced to 1 sec with smart delay centering + hash caching

--- a/vsg_core/subtitles/frame_sync.py
+++ b/vsg_core/subtitles/frame_sync.py
@@ -2460,10 +2460,8 @@ def verify_correlation_with_frame_snap(
     hash_algorithm = config.get('correlation_snap_hash_algorithm', 'dhash')
     hash_size = int(config.get('correlation_snap_hash_size', 8))
     hash_threshold = int(config.get('correlation_snap_hash_threshold', 5))
-    adjacent_frames = int(config.get('correlation_snap_adjacent_frames', 3))
 
     runner._log_message(f"[Correlation+FrameSnap] Hash: {hash_algorithm}, size={hash_size}, threshold={hash_threshold}")
-    runner._log_message(f"[Correlation+FrameSnap] Adjacent frames to check: ±{adjacent_frames}")
 
     # Import frame matching utilities
     try:
@@ -2518,8 +2516,10 @@ def verify_correlation_with_frame_snap(
 
     use_scene_checkpoints = config.get('correlation_snap_use_scene_changes', True)
     refinements_ms = []  # Refinements calculated from sliding window alignment
-    window_radius = 3  # 3 frames before and after center = 7 frame window
-    search_range_frames = 5  # Search ±5 frames around predicted position (±~200ms)
+
+    # Get sliding window parameters from config
+    window_radius = int(config.get('correlation_snap_window_radius', 3))  # 3 = 7 frame window
+    search_range_frames = int(config.get('correlation_snap_search_range', 5))  # Search ±N frames
 
     # Import frame matching utilities
     try:

--- a/vsg_qt/options_dialog/tabs.py
+++ b/vsg_qt/options_dialog/tabs.py
@@ -1418,18 +1418,30 @@ class SubtitleSyncTab(QWidget):
             "Lower = stricter matching."
         )
 
-        self.widgets['correlation_snap_adjacent_frames'] = QSpinBox()
-        self.widgets['correlation_snap_adjacent_frames'].setRange(1, 10)
-        self.widgets['correlation_snap_adjacent_frames'].setValue(3)
-        self.widgets['correlation_snap_adjacent_frames'].setToolTip(
-            "Adjacent frames to check around each checkpoint:\n\n"
-            "For each checkpoint, extracts ±N frames and compares.\n"
-            "More frames = more robust but slower.\n\n"
-            "• 1: Minimal (3 frames total)\n"
-            "• 3 (Default): Good balance (7 frames total)\n"
-            "• 5: More thorough (11 frames total)\n"
-            "• 10: Very thorough but slow (21 frames)\n\n"
-            "Recommendation: 3 for most cases."
+        self.widgets['correlation_snap_window_radius'] = QSpinBox()
+        self.widgets['correlation_snap_window_radius'].setRange(1, 10)
+        self.widgets['correlation_snap_window_radius'].setValue(3)
+        self.widgets['correlation_snap_window_radius'].setToolTip(
+            "Sliding window radius (frames before/after center):\n\n"
+            "Creates a window of (2*N+1) frames centered on scene change.\n"
+            "Used to match a sequence of frames, not just one.\n\n"
+            "• 1: 3 frame window (minimal)\n"
+            "• 3 (Default): 7 frame window (recommended)\n"
+            "• 5: 11 frame window (more robust)\n\n"
+            "Larger = more robust matching but slower."
+        )
+
+        self.widgets['correlation_snap_search_range'] = QSpinBox()
+        self.widgets['correlation_snap_search_range'].setRange(1, 30)
+        self.widgets['correlation_snap_search_range'].setValue(5)
+        self.widgets['correlation_snap_search_range'].setToolTip(
+            "Search range around correlation prediction (±N frames):\n\n"
+            "After correlation predicts target position, we search\n"
+            "±N frames to find the best frame alignment.\n\n"
+            "• 5 (Default): Good for remux vs remux (~200ms)\n"
+            "• 10-15: For encodes or larger timing differences\n"
+            "• 20-30: For very different sources\n\n"
+            "Increase if best match is at edge of search window."
         )
 
         # Frame-Matched settings
@@ -1598,7 +1610,8 @@ class SubtitleSyncTab(QWidget):
         sync_layout.addRow("Corr+Snap Fallback:", self.widgets['correlation_snap_fallback_mode'])
         sync_layout.addRow("Corr+Snap Hash:", self.widgets['correlation_snap_hash_algorithm'])
         sync_layout.addRow("Corr+Snap Threshold:", self.widgets['correlation_snap_hash_threshold'])
-        sync_layout.addRow("Corr+Snap Adj. Frames:", self.widgets['correlation_snap_adjacent_frames'])
+        sync_layout.addRow("Corr+Snap Window:", self.widgets['correlation_snap_window_radius'])
+        sync_layout.addRow("Corr+Snap Search:", self.widgets['correlation_snap_search_range'])
         sync_layout.addRow("", self.widgets['frame_match_use_vapoursynth'])
         sync_layout.addRow("Match Window:", self.widgets['frame_match_search_window_sec'])
         sync_layout.addRow("Match Threshold:", self.widgets['frame_match_threshold'])
@@ -1671,7 +1684,8 @@ class SubtitleSyncTab(QWidget):
         self.widgets['correlation_snap_fallback_mode'].setEnabled(is_correlation_snap)
         self.widgets['correlation_snap_hash_algorithm'].setEnabled(is_correlation_snap)
         self.widgets['correlation_snap_hash_threshold'].setEnabled(is_correlation_snap)
-        self.widgets['correlation_snap_adjacent_frames'].setEnabled(is_correlation_snap)
+        self.widgets['correlation_snap_window_radius'].setEnabled(is_correlation_snap)
+        self.widgets['correlation_snap_search_range'].setEnabled(is_correlation_snap)
 
 class ChaptersTab(QWidget):
     def __init__(self):


### PR DESCRIPTION
New config options (with defaults that preserve current behavior):
- correlation_snap_window_radius: 3 (7 frame window)
- correlation_snap_search_range: 5 (±5 frames around prediction)
- correlation_snap_use_scene_changes: True

For encodes with compression differences:
- Increase search_range to 10-15 (or higher if needed)
- Increase hash_threshold to 15-20 for looser matching

UI updates:
- Added "Corr+Snap Window" spinbox (1-10, default 3)
- Added "Corr+Snap Search" spinbox (1-30, default 5)
- Renamed adjacent_frames to window_radius for clarity

The search range determines how far from the correlation prediction we look for frame matches. If best match is at the edge (±5), it means the real match is beyond the search window - increase range.