### PR TITLE
Add audit warning when correlation-frame-snap uses raw delay fallback

### DIFF
--- a/vsg_core/orchestrator/steps/context.py
+++ b/vsg_core/orchestrator/steps/context.py
@@ -62,6 +62,10 @@ class Context:
     # Format: {source_key: List[AudioSegment]}
     stepping_edls: Dict[str, List[Any]] = field(default_factory=dict)
 
+    # Flag if any subtitle track used raw delay fallback due to no scene matches
+    # (correlation-frame-snap mode couldn't find scenes to verify against)
+    correlation_snap_no_scenes_fallback: bool = False
+
     # Results/summaries
     out_file: Optional[str] = None
     tokens: Optional[List[str]] = None

--- a/vsg_core/postprocess/auditors/subtitle_formats.py
+++ b/vsg_core/postprocess/auditors/subtitle_formats.py
@@ -101,6 +101,13 @@ class SubtitleFormatsAuditor(BaseAuditor):
 
             final_subtitle_idx += 1
 
+        # Check if any subtitle tracks used raw delay fallback due to no scene matches
+        if getattr(self.ctx, 'correlation_snap_no_scenes_fallback', False):
+            self.log(f"[WARNING] One or more subtitle tracks used raw delay (no scene matches found)")
+            self.log(f"          → Frame verification was skipped, using correlation only")
+            self.log(f"          → Review logs to confirm timing is correct")
+            issues += 1
+
         if issues == 0:
             self.log("✅ All subtitle processing verified correctly.")
 


### PR DESCRIPTION
When subtitle tracks have no scene matches (sparse signs/songs), the correlation-frame-snap mode falls back to raw delay. This adds an audit warning so users know to double-check the timing for those tracks.

Changes:
- Add correlation_snap_no_scenes_fallback flag to Context
- Track during subtitle sync if any track had 0 scene matches
- Set flag once at end of subtitle step (not per-track)
- SubtitleFormatsAuditor shows warning if flag is set

The warning appears in the final audit:
[WARNING] One or more subtitle tracks used raw delay (no scene matches found)
          → Frame verification was skipped, using correlation only
          → Review logs to confirm timing is correct