### PR TITLE
Fix: Raw delay mode now works like correlation-frame-snap

### DIFF
--- a/vsg_core/subtitles/frame_sync.py
+++ b/vsg_core/subtitles/frame_sync.py
@@ -930,40 +930,37 @@ def apply_raw_delay_sync(
     delay_ms: float,
     runner,
     config: dict = None,
-    rounding_mode: str = 'round'
+    rounding_mode: str = 'floor'
 ) -> Dict[str, Any]:
     """
-    Apply raw audio delay with ASS centisecond precision rounding.
+    Apply raw audio delay using the same logic as correlation-frame-snap mode.
 
-    This is a pure delay mode for testing/debugging:
-    1. Load subtitles
-    2. Add raw delay to all timestamps
-    3. Round to centisecond precision (10ms for ASS format)
+    This mode does everything correlation-frame-snap does EXCEPT scene detection:
+    1. Load subtitles via pysubs2
+    2. Apply raw delay with floor rounding at final step
+    3. Preserve metadata (Aegisub extradata, etc.)
     4. Save subtitles
 
-    NO frame analysis, NO VideoTimestamps - just pure math.
-    Useful for isolating whether frame correction is causing sync issues.
+    Same calculations as correlation-frame-snap's no-scene-matches path.
+    Use this when you want the benefits of pysubs2 processing without frame verification.
 
     Args:
         subtitle_path: Path to subtitle file (.ass, .srt, .ssa, .vtt)
         delay_ms: Raw audio delay (unrounded float, full precision)
         runner: CommandRunner for logging
-        config: Optional config dict (unused, for API compatibility)
-        rounding_mode: How to round to centiseconds:
-            - 'floor': Round down (1065.458ms → 1060ms)
-            - 'round': Round to nearest (1065.458ms → 1070ms)
-            - 'ceil': Round up (1065.458ms → 1070ms)
+        config: Optional config dict
+        rounding_mode: How to round final offset (default: 'floor')
 
     Returns:
         Dict with report statistics
     """
     config = config or {}
-    rounding_mode = config.get('raw_delay_rounding', rounding_mode)
 
-    runner._log_message(f"[Raw Delay Sync] Mode: Pure delay + centisecond rounding")
+    runner._log_message(f"[Raw Delay Sync] ═══════════════════════════════════════")
+    runner._log_message(f"[Raw Delay Sync] Raw Delay Mode (no scene detection)")
+    runner._log_message(f"[Raw Delay Sync] ═══════════════════════════════════════")
     runner._log_message(f"[Raw Delay Sync] Loading subtitle: {Path(subtitle_path).name}")
     runner._log_message(f"[Raw Delay Sync] Raw audio delay: {delay_ms:+.3f}ms")
-    runner._log_message(f"[Raw Delay Sync] Rounding mode: {rounding_mode}")
 
     # Capture original metadata before pysubs2 processing
     metadata = SubtitleMetadata(subtitle_path)
@@ -979,36 +976,30 @@ def apply_raw_delay_sync(
     if not subs.events:
         runner._log_message(f"[Raw Delay Sync] WARNING: No subtitle events found in file")
         return {
+            'success': True,
             'total_events': 0,
-            'delay_applied_ms': delay_ms
+            'raw_delay_ms': delay_ms,
+            'final_offset_applied': 0
         }
 
     runner._log_message(f"[Raw Delay Sync] Loaded {len(subs.events)} subtitle events")
 
-    # Apply delay to all events
+    # Calculate final offset using floor (same as correlation-frame-snap)
+    final_offset_ms = delay_ms
+    final_offset_int = int(math.floor(final_offset_ms))
+
+    runner._log_message(f"[Raw Delay Sync] ───────────────────────────────────────")
+    runner._log_message(f"[Raw Delay Sync] Final offset calculation:")
+    runner._log_message(f"[Raw Delay Sync]   Raw delay:        {delay_ms:+.3f}ms")
+    runner._log_message(f"[Raw Delay Sync]   Floor applied:    {final_offset_int:+d}ms")
+    runner._log_message(f"[Raw Delay Sync] ───────────────────────────────────────")
+
+    # Apply offset to all events (same as correlation-frame-snap)
+    runner._log_message(f"[Raw Delay Sync] Applying offset to {len(subs.events)} events...")
+
     for event in subs.events:
-        # Add raw delay
-        new_start_ms = event.start + delay_ms
-        new_end_ms = event.end + delay_ms
-
-        # Round to centiseconds (10ms precision for ASS)
-        if rounding_mode == 'floor':
-            event.start = int(new_start_ms // 10) * 10
-            event.end = int(new_end_ms // 10) * 10
-        elif rounding_mode == 'ceil':
-            event.start = int(math.ceil(new_start_ms / 10)) * 10
-            event.end = int(math.ceil(new_end_ms / 10)) * 10
-        else:  # 'round' (default)
-            event.start = int(round(new_start_ms / 10)) * 10
-            event.end = int(round(new_end_ms / 10)) * 10
-
-    # Calculate what the delay became after rounding
-    # Use first event as example
-    if subs.events:
-        first_event_original = metadata.metadata.get('first_event_start', 0)
-        first_event_new = subs.events[0].start
-        actual_delay = first_event_new - first_event_original
-        runner._log_message(f"[Raw Delay Sync] Example: First event shifted by {actual_delay:+.0f}ms (after rounding)")
+        event.start += final_offset_int
+        event.end += final_offset_int
 
     # Save modified subtitle
     runner._log_message(f"[Raw Delay Sync] Saving modified subtitle file...")
@@ -1019,17 +1010,17 @@ def apply_raw_delay_sync(
         return {'error': str(e)}
 
     # Validate and restore lost metadata
-    metadata.validate_and_restore(runner, expected_delay_ms=int(round(delay_ms)))
+    metadata.validate_and_restore(runner, expected_delay_ms=final_offset_int)
 
-    # Log results
-    runner._log_message(f"[Raw Delay Sync] ✓ Successfully synchronized {len(subs.events)} events")
-    runner._log_message(f"[Raw Delay Sync]   - Raw delay applied: {delay_ms:+.3f}ms")
-    runner._log_message(f"[Raw Delay Sync]   - Rounding mode: {rounding_mode}")
+    runner._log_message(f"[Raw Delay Sync] Successfully synchronized {len(subs.events)} events")
+    runner._log_message(f"[Raw Delay Sync] ═══════════════════════════════════════")
 
     return {
+        'success': True,
         'total_events': len(subs.events),
         'raw_delay_ms': delay_ms,
-        'rounding_mode': rounding_mode
+        'final_offset_ms': final_offset_ms,
+        'final_offset_applied': final_offset_int
     }
 
 


### PR DESCRIPTION
Fixed bug: 'SubtitleMetadata' object has no attribute 'metadata'

Rewrote apply_raw_delay_sync to use the same logic as correlation-frame-snap:
- Uses floor rounding at final step (not centisecond/10ms rounding)
- Same offset calculation: final_offset_int = int(math.floor(delay_ms))
- Same event modification: event.start += final_offset_int
- Same metadata preservation via SubtitleMetadata
- Similar logging format for consistency

Raw mode is now essentially correlation-frame-snap minus scene detection. This gives the benefits of pysubs2 processing without frame verification.