### PR TITLE
Fix multi-correlation to only run in Analyze Only mode

### DIFF
--- a/vsg_core/orchestrator/steps/analysis_step.py
+++ b/vsg_core/orchestrator/steps/analysis_step.py
@@ -355,8 +355,8 @@ class AnalysisStep:
                 runner._log_message(f"[WARN] No suitable audio track found in {source_key} for analysis. Skipping.")
                 continue
 
-            # Check if multi-correlation comparison is enabled
-            multi_corr_enabled = config.get('multi_correlation_enabled', False)
+            # Check if multi-correlation comparison is enabled (Analyze Only mode only)
+            multi_corr_enabled = config.get('multi_correlation_enabled', False) and not ctx.and_merge
 
             if multi_corr_enabled:
                 # Run multiple correlation methods for comparison


### PR DESCRIPTION
Added check for `not ctx.and_merge` to ensure multi-correlation comparison only activates during Analyze Only runs, not during regular Analyze & Merge jobs.