### PR TITLE
Add Subtitle-Anchored Frame Snap sync mode

### DIFF
--- a/vsg_core/config.py
+++ b/vsg_core/config.py
@@ -66,6 +66,17 @@ class AppConfig:
             'correlation_snap_search_range': 5,  # Search ±N frames around correlation prediction (increase for encodes)
             'correlation_snap_use_scene_changes': True,  # Use PySceneDetect to find anchor points
 
+            # --- Subtitle-Anchored Frame Snap Settings ---
+            # Visual-only sync using subtitle positions as anchors (no audio correlation dependency)
+            'sub_anchor_search_range_ms': 2000,  # Search ±N ms around expected position (default 2000 = ~48 frames at 24fps)
+            'sub_anchor_hash_algorithm': 'dhash',  # Hash algorithm: 'dhash', 'phash', 'average_hash'
+            'sub_anchor_hash_size': 8,  # Hash size for perceptual hashing (8 = 64-bit)
+            'sub_anchor_hash_threshold': 5,  # Max hamming distance for frame match
+            'sub_anchor_window_radius': 5,  # Frames before/after center (5 = 11 frame window)
+            'sub_anchor_agreement_tolerance_ms': 100,  # Checkpoints must agree within ±N ms
+            'sub_anchor_fallback_mode': 'abort',  # What to do if verification fails: 'abort', 'use-median'
+            'sub_anchor_use_vapoursynth': True,  # Use VapourSynth for frame extraction (faster with cache)
+
             # --- Timing Fix Settings ---
             'timing_fix_enabled': False,
             'timing_fix_overlaps': True,

--- a/vsg_core/orchestrator/steps/subtitles_step.py
+++ b/vsg_core/orchestrator/steps/subtitles_step.py
@@ -17,7 +17,7 @@ from vsg_core.subtitles.ocr import run_ocr
 from vsg_core.subtitles.cleanup import run_cleanup
 from vsg_core.subtitles.timing import fix_subtitle_timing
 from vsg_core.subtitles.stepping_adjust import apply_stepping_to_subtitles
-from vsg_core.subtitles.frame_sync import apply_raw_delay_sync, apply_duration_align_sync, apply_correlation_frame_snap_sync
+from vsg_core.subtitles.frame_sync import apply_raw_delay_sync, apply_duration_align_sync, apply_correlation_frame_snap_sync, apply_subtitle_anchored_frame_snap_sync
 
 class SubtitlesStep:
     def run(self, ctx: Context, runner: CommandRunner) -> Context:
@@ -240,7 +240,7 @@ class SubtitlesStep:
                             runner._log_message(f"[Time-Based Raw] Skipping track {item.track.id} - format {ext} not supported")
                     # else: default time-based mode uses mkvmerge --sync, no processing needed here
 
-                elif subtitle_sync_mode in ['duration-align', 'correlation-frame-snap']:
+                elif subtitle_sync_mode in ['duration-align', 'correlation-frame-snap', 'subtitle-anchored-frame-snap']:
                     # Check if this subtitle format supports advanced sync
                     ext = item.extracted_path.suffix.lower()
                     supported_formats = ['.ass', '.ssa', '.srt', '.vtt']
@@ -396,6 +396,56 @@ class SubtitlesStep:
                                 runner._log_message(f"[Correlation+FrameSnap] ERROR: Missing source or target video")
                                 runner._log_message(f"[Correlation+FrameSnap] Source: {source_video}, Target: {target_video}")
                                 raise RuntimeError(f"Correlation+FrameSnap sync failed: missing source/target video")
+
+                        # Subtitle-Anchored Frame Snap mode: Visual-only sync using subtitle positions
+                        if subtitle_sync_mode == 'subtitle-anchored-frame-snap':
+                            # Requires source and target videos
+                            source_key = item.sync_to if item.track.source == 'External' else item.track.source
+                            source_video = ctx.sources.get(source_key)
+                            target_video = source1_file
+
+                            # Get raw global shift (NOT source-specific delay)
+                            # This mode does NOT depend on audio correlation
+                            global_shift_ms = 0.0
+                            if ctx.delays:
+                                global_shift_ms = ctx.delays.raw_global_shift_ms
+                                runner._log_message(f"[SubAnchor FrameSnap] Using raw global shift: {global_shift_ms:+.3f}ms")
+
+                            if source_video and target_video:
+                                runner._log_message(f"[SubAnchor FrameSnap] Applying to track {item.track.id} ({item.track.props.name or 'Unnamed'})")
+                                runner._log_message(f"[SubAnchor FrameSnap] Source video: {Path(source_video).name}")
+                                runner._log_message(f"[SubAnchor FrameSnap] Target video: {Path(target_video).name}")
+
+                                frame_sync_report = apply_subtitle_anchored_frame_snap_sync(
+                                    str(item.extracted_path),
+                                    str(source_video),
+                                    str(target_video),
+                                    global_shift_ms,
+                                    runner,
+                                    ctx.settings_dict
+                                )
+
+                                if frame_sync_report and frame_sync_report.get('success'):
+                                    runner._log_message(f"--- SubAnchor FrameSnap Sync Report ---")
+                                    for key, value in frame_sync_report.items():
+                                        if key not in ('verification', 'checkpoints'):  # Skip nested dicts
+                                            runner._log_message(f"  - {key.replace('_', ' ').title()}: {value}")
+                                    runner._log_message("------------------------------------------")
+                                    # Mark that timestamps have been adjusted
+                                    item.frame_adjusted = True
+                                elif frame_sync_report and 'error' in frame_sync_report:
+                                    # Sync function returned error
+                                    error_msg = frame_sync_report['error']
+                                    runner._log_message(f"[SubAnchor FrameSnap] ERROR: Sync failed for track {item.track.id}: {error_msg}")
+                                    raise RuntimeError(f"SubAnchor FrameSnap sync failed for track {item.track.id}: {error_msg}")
+                                else:
+                                    # No report or unexpected result
+                                    runner._log_message(f"[SubAnchor FrameSnap] ERROR: No sync report returned for track {item.track.id}")
+                                    raise RuntimeError(f"SubAnchor FrameSnap sync failed for track {item.track.id}: No report returned")
+                            else:
+                                runner._log_message(f"[SubAnchor FrameSnap] ERROR: Missing source or target video")
+                                runner._log_message(f"[SubAnchor FrameSnap] Source: {source_video}, Target: {target_video}")
+                                raise RuntimeError(f"SubAnchor FrameSnap sync failed: missing source/target video")
 
                     else:
                         # Unsupported format (PGS/VOB bitmap subtitles)

--- a/vsg_core/subtitles/frame_sync.py
+++ b/vsg_core/subtitles/frame_sync.py
@@ -2576,3 +2576,433 @@ def apply_correlation_frame_snap_sync(
         'frame_duration_ms': frame_duration_ms,
         'verification': verification_result
     }
+
+
+# ============================================================================
+# SUBTITLE-ANCHORED FRAME SNAP MODE
+# ============================================================================
+
+def apply_subtitle_anchored_frame_snap_sync(
+    subtitle_path: str,
+    source_video: str,
+    target_video: str,
+    global_shift_ms: float,
+    runner,
+    config: dict = None
+) -> Dict[str, Any]:
+    """
+    Subtitle-Anchored Frame Snap: Visual-only sync using subtitle positions as anchors.
+
+    This mode combines the reliability of Duration-Align's frame selection (subtitle positions)
+    with FrameSnap's sliding window matching, WITHOUT depending on audio correlation.
+
+    Algorithm:
+    1. Select 3 dialogue events as checkpoints (first, middle, last - avoiding OP/ED)
+    2. For each checkpoint:
+       a. Get source frame at subtitle.start_time
+       b. Extract window of frames: center ± N frames
+       c. Compute dHash for all frames in window
+    3. In target video, search around expected position:
+       - Base offset: 0 (or user-provided hint)
+       - Search range: ±configurable ms (default 2000ms = ~48 frames at 24fps)
+       - Slide the frame window through target, find best match
+    4. Calculate sub-frame timing:
+       - Source subtitle starts at exact time (e.g., 149630.5ms)
+       - Source frame containing that time starts at frame boundary (e.g., 149604.6ms)
+       - Sub-frame offset = subtitle_start - frame_start (e.g., 25.9ms)
+       - Apply same sub-frame offset to matched target frame
+    5. Verify all 3 checkpoints agree within tolerance
+    6. Apply final offset (preserving sub-frame precision until final floor)
+
+    This mode is ideal when:
+    - Audio correlation fails or is unavailable
+    - Videos are frame-aligned but with unknown offset
+    - Scene detection picks bad frames (black, transitions)
+    - You want purely visual-based sync
+
+    Args:
+        subtitle_path: Path to subtitle file
+        source_video: Path to source video (where subs were authored)
+        target_video: Path to target video (Source 1)
+        global_shift_ms: Global shift from ctx.delays.raw_global_shift_ms
+        runner: CommandRunner for logging
+        config: Configuration dict with:
+            - sub_anchor_search_range_ms: ±search range in ms (default: 2000)
+            - sub_anchor_hash_algorithm: 'dhash', 'phash', 'average_hash' (default: 'dhash')
+            - sub_anchor_hash_size: 8, 16 (default: 8)
+            - sub_anchor_hash_threshold: max hamming distance (default: 5)
+            - sub_anchor_window_radius: frames before/after center (default: 5)
+            - sub_anchor_agreement_tolerance_ms: checkpoint agreement (default: 100)
+            - sub_anchor_fallback_mode: 'abort', 'use-median' (default: 'abort')
+            - sub_anchor_use_vapoursynth: use VS for frame extraction (default: True)
+
+    Returns:
+        Dict with sync report including:
+            - success: bool
+            - total_events: int
+            - final_offset_ms: float (precise)
+            - final_offset_applied: int (floored)
+            - checkpoints: List[Dict] with per-checkpoint details
+            - verification: Dict with agreement info
+    """
+    config = config or {}
+
+    runner._log_message(f"[SubAnchor FrameSnap] ═══════════════════════════════════════")
+    runner._log_message(f"[SubAnchor FrameSnap] Subtitle-Anchored Frame Snap Sync Mode")
+    runner._log_message(f"[SubAnchor FrameSnap] ═══════════════════════════════════════")
+    runner._log_message(f"[SubAnchor FrameSnap] Visual-only sync using subtitle positions as anchors")
+    runner._log_message(f"[SubAnchor FrameSnap] No audio correlation dependency")
+
+    # Get config parameters
+    search_range_ms = config.get('sub_anchor_search_range_ms', 2000)
+    hash_algorithm = config.get('sub_anchor_hash_algorithm', 'dhash')
+    hash_size = int(config.get('sub_anchor_hash_size', 8))
+    hash_threshold = int(config.get('sub_anchor_hash_threshold', 5))
+    window_radius = int(config.get('sub_anchor_window_radius', 5))
+    tolerance_ms = config.get('sub_anchor_agreement_tolerance_ms', 100)
+    fallback_mode = config.get('sub_anchor_fallback_mode', 'abort')
+    use_vapoursynth = config.get('sub_anchor_use_vapoursynth', True)
+
+    runner._log_message(f"[SubAnchor FrameSnap] Configuration:")
+    runner._log_message(f"[SubAnchor FrameSnap]   Search range: ±{search_range_ms}ms")
+    runner._log_message(f"[SubAnchor FrameSnap]   Hash: {hash_algorithm}, size={hash_size}, threshold={hash_threshold}")
+    runner._log_message(f"[SubAnchor FrameSnap]   Window radius: {window_radius} frames (={2*window_radius+1} total)")
+    runner._log_message(f"[SubAnchor FrameSnap]   Agreement tolerance: ±{tolerance_ms}ms")
+    runner._log_message(f"[SubAnchor FrameSnap]   Fallback mode: {fallback_mode}")
+    runner._log_message(f"[SubAnchor FrameSnap]   Global shift: {global_shift_ms:+.3f}ms")
+
+    # Load subtitle file
+    try:
+        subs = pysubs2.load(subtitle_path, encoding='utf-8')
+    except Exception as e:
+        runner._log_message(f"[SubAnchor FrameSnap] ERROR: Failed to load subtitle file: {e}")
+        return {
+            'success': False,
+            'error': f'Failed to load subtitle file: {e}'
+        }
+
+    if not subs.events:
+        runner._log_message(f"[SubAnchor FrameSnap] WARNING: No subtitle events found")
+        return {
+            'success': True,
+            'total_events': 0,
+            'final_offset_ms': global_shift_ms,
+            'final_offset_applied': int(math.floor(global_shift_ms)),
+            'warning': 'No subtitle events - applied global shift only'
+        }
+
+    runner._log_message(f"[SubAnchor FrameSnap] Loaded {len(subs.events)} subtitle events")
+
+    # Filter to dialogue events (must have text content)
+    dialogue_events = [e for e in subs.events if e.text and e.text.strip()]
+    runner._log_message(f"[SubAnchor FrameSnap] Found {len(dialogue_events)} events with text content")
+
+    if len(dialogue_events) < 1:
+        runner._log_message(f"[SubAnchor FrameSnap] ERROR: No dialogue events found")
+        return {
+            'success': False,
+            'error': 'No dialogue events with text content found'
+        }
+
+    # Select smart checkpoints (avoid OP/ED, prefer longer dialogue)
+    checkpoints = _select_smart_checkpoints(dialogue_events, runner)
+
+    if len(checkpoints) == 0:
+        runner._log_message(f"[SubAnchor FrameSnap] ERROR: No valid checkpoints found")
+        return {
+            'success': False,
+            'error': 'No valid checkpoints for frame matching'
+        }
+
+    runner._log_message(f"[SubAnchor FrameSnap] Selected {len(checkpoints)} checkpoints for matching")
+
+    # Import frame matching utilities
+    try:
+        from .frame_matching import VideoReader, compute_frame_hash
+    except ImportError:
+        runner._log_message(f"[SubAnchor FrameSnap] ERROR: frame_matching module not available")
+        return {
+            'success': False,
+            'error': 'frame_matching module not available'
+        }
+
+    # Get video FPS for frame timing calculations
+    source_fps = detect_video_fps(source_video, runner)
+    target_fps = detect_video_fps(target_video, runner)
+    frame_duration_ms = 1000.0 / source_fps
+
+    runner._log_message(f"[SubAnchor FrameSnap] Source FPS: {source_fps:.3f} (frame duration: {frame_duration_ms:.3f}ms)")
+    runner._log_message(f"[SubAnchor FrameSnap] Target FPS: {target_fps:.3f}")
+
+    # Open video readers
+    try:
+        source_reader = VideoReader(source_video, runner)
+        target_reader = VideoReader(target_video, runner)
+    except Exception as e:
+        runner._log_message(f"[SubAnchor FrameSnap] ERROR: Failed to open videos: {e}")
+        return {
+            'success': False,
+            'error': f'Failed to open videos: {e}'
+        }
+
+    # Process each checkpoint
+    measurements = []  # List of precise offset measurements
+    checkpoint_details = []
+    num_frames_in_window = 2 * window_radius + 1
+    median_offset = 0.0
+    max_deviation = 0.0
+
+    for i, event in enumerate(checkpoints):
+        subtitle_start_ms = event.start  # Exact subtitle start time
+        runner._log_message(f"[SubAnchor FrameSnap] ───────────────────────────────────────")
+        runner._log_message(f"[SubAnchor FrameSnap] Checkpoint {i+1}/{len(checkpoints)}: {subtitle_start_ms}ms")
+        runner._log_message(f"[SubAnchor FrameSnap]   Text preview: \"{event.text[:50]}...\"" if len(event.text) > 50 else f"[SubAnchor FrameSnap]   Text: \"{event.text}\"")
+
+        # Calculate source frame containing this subtitle
+        source_center_frame = time_to_frame_floor(subtitle_start_ms, source_fps)
+        source_frame_start_ms = frame_to_time_floor(source_center_frame, source_fps)
+        sub_frame_offset_ms = subtitle_start_ms - source_frame_start_ms
+
+        runner._log_message(f"[SubAnchor FrameSnap]   Source frame: {source_center_frame} (starts at {source_frame_start_ms:.3f}ms)")
+        runner._log_message(f"[SubAnchor FrameSnap]   Sub-frame offset: {sub_frame_offset_ms:.3f}ms into frame")
+
+        # Step 1: Extract and hash source frames (center ± window_radius)
+        source_frame_hashes = []  # List of (frame_offset, hash)
+        for offset in range(-window_radius, window_radius + 1):
+            frame_num = source_center_frame + offset
+            if frame_num < 0:
+                continue
+
+            frame = source_reader.get_frame_at_index(frame_num)
+            if frame is not None:
+                frame_hash = compute_frame_hash(frame, hash_size=hash_size, method=hash_algorithm)
+                if frame_hash is not None:
+                    source_frame_hashes.append((offset, frame_hash))
+
+        if len(source_frame_hashes) < num_frames_in_window * 0.7:  # Need at least 70%
+            runner._log_message(f"[SubAnchor FrameSnap]   WARNING: Not enough source frames ({len(source_frame_hashes)}/{num_frames_in_window})")
+            checkpoint_details.append({
+                'checkpoint_ms': subtitle_start_ms,
+                'matched': False,
+                'error': f'Not enough source frames ({len(source_frame_hashes)}/{num_frames_in_window})'
+            })
+            continue
+
+        runner._log_message(f"[SubAnchor FrameSnap]   Extracted {len(source_frame_hashes)} source frames")
+
+        # Step 2: Search in target video
+        # Search window: start from source time (assuming similar timing), expand ±search_range_ms
+        search_center_ms = subtitle_start_ms  # Start at same position (offset unknown)
+        search_start_ms = max(0, search_center_ms - search_range_ms)
+        search_end_ms = search_center_ms + search_range_ms
+
+        # Convert to frame numbers for efficient searching
+        search_start_frame = time_to_frame_floor(search_start_ms, target_fps)
+        search_end_frame = time_to_frame_floor(search_end_ms, target_fps)
+
+        runner._log_message(f"[SubAnchor FrameSnap]   Searching frames {search_start_frame}-{search_end_frame} ({search_end_frame - search_start_frame + 1} positions)")
+
+        # Track best match
+        best_match_frame = None
+        best_aggregate_score = -1
+        best_matched_count = 0
+        best_avg_distance = float('inf')
+
+        # Search every frame in range (we want precision, not speed here)
+        for target_center_frame in range(search_start_frame, search_end_frame + 1):
+            # For this candidate, compare all frames in window
+            matched_frames = 0
+            total_distance = 0
+            frames_compared = 0
+
+            for offset, source_hash in source_frame_hashes:
+                target_frame_num = target_center_frame + offset
+                if target_frame_num < 0:
+                    continue
+
+                target_frame = target_reader.get_frame_at_index(target_frame_num)
+                if target_frame is not None:
+                    target_hash = compute_frame_hash(target_frame, hash_size=hash_size, method=hash_algorithm)
+                    if target_hash is not None:
+                        distance = source_hash - target_hash
+                        frames_compared += 1
+
+                        if distance <= hash_threshold:
+                            matched_frames += 1
+
+                        total_distance += distance
+
+            # Calculate aggregate score: prioritize match count, then lower distance
+            if frames_compared > 0:
+                avg_distance = total_distance / frames_compared
+                # Score = matched * 1000 - avg_distance (higher is better)
+                aggregate_score = (matched_frames * 1000) - avg_distance
+
+                if aggregate_score > best_aggregate_score:
+                    best_aggregate_score = aggregate_score
+                    best_match_frame = target_center_frame
+                    best_matched_count = matched_frames
+                    best_avg_distance = avg_distance
+
+        # Step 3: Validate match quality
+        min_required_matches = int(len(source_frame_hashes) * 0.70)  # 70% threshold
+
+        if best_match_frame is not None and best_matched_count >= min_required_matches:
+            # Calculate precise offset with sub-frame timing
+            target_frame_start_ms = frame_to_time_floor(best_match_frame, target_fps)
+            # Target subtitle should start at: target_frame_start + sub_frame_offset
+            target_subtitle_time_ms = target_frame_start_ms + sub_frame_offset_ms
+
+            # Precise offset = where subtitle should be in target - where it is in source
+            precise_offset_ms = target_subtitle_time_ms - subtitle_start_ms
+
+            match_percent = (best_matched_count / len(source_frame_hashes)) * 100
+            measurements.append(precise_offset_ms)
+
+            runner._log_message(f"[SubAnchor FrameSnap]   ✓ Match found!")
+            runner._log_message(f"[SubAnchor FrameSnap]     Target frame: {best_match_frame} (starts at {target_frame_start_ms:.3f}ms)")
+            runner._log_message(f"[SubAnchor FrameSnap]     Frames matched: {best_matched_count}/{len(source_frame_hashes)} ({match_percent:.0f}%)")
+            runner._log_message(f"[SubAnchor FrameSnap]     Average distance: {best_avg_distance:.1f}")
+            runner._log_message(f"[SubAnchor FrameSnap]     Precise offset: {precise_offset_ms:+.3f}ms")
+
+            checkpoint_details.append({
+                'checkpoint_ms': subtitle_start_ms,
+                'source_frame': source_center_frame,
+                'target_frame': best_match_frame,
+                'sub_frame_offset_ms': sub_frame_offset_ms,
+                'precise_offset_ms': precise_offset_ms,
+                'matched_frames': best_matched_count,
+                'total_frames': len(source_frame_hashes),
+                'match_percent': match_percent,
+                'avg_distance': best_avg_distance,
+                'matched': True
+            })
+        else:
+            match_percent = (best_matched_count / len(source_frame_hashes) * 100) if best_matched_count > 0 else 0
+            runner._log_message(f"[SubAnchor FrameSnap]   ✗ No good match found")
+            runner._log_message(f"[SubAnchor FrameSnap]     Best: {best_matched_count}/{len(source_frame_hashes)} ({match_percent:.0f}%)")
+            runner._log_message(f"[SubAnchor FrameSnap]     Required: {min_required_matches} (70%)")
+
+            checkpoint_details.append({
+                'checkpoint_ms': subtitle_start_ms,
+                'matched': False,
+                'best_matched': best_matched_count,
+                'required': min_required_matches,
+                'match_percent': match_percent
+            })
+
+    # Clean up video readers
+    del source_reader
+    del target_reader
+    gc.collect()
+
+    runner._log_message(f"[SubAnchor FrameSnap] ───────────────────────────────────────")
+    runner._log_message(f"[SubAnchor FrameSnap] Results Summary")
+    runner._log_message(f"[SubAnchor FrameSnap] ───────────────────────────────────────")
+
+    # Check results
+    if len(measurements) == 0:
+        runner._log_message(f"[SubAnchor FrameSnap] ERROR: No checkpoints matched successfully")
+        if fallback_mode == 'abort':
+            return {
+                'success': False,
+                'error': 'No checkpoints matched - cannot determine sync offset',
+                'checkpoints': checkpoint_details
+            }
+        else:
+            # Use global shift only
+            runner._log_message(f"[SubAnchor FrameSnap] Fallback: Using global shift only ({global_shift_ms:+.3f}ms)")
+            final_offset_ms = global_shift_ms
+
+    elif len(measurements) == 1:
+        # Only one checkpoint - use it but warn
+        runner._log_message(f"[SubAnchor FrameSnap] WARNING: Only 1 checkpoint matched (cannot verify agreement)")
+        runner._log_message(f"[SubAnchor FrameSnap] Using single measurement: {measurements[0]:+.3f}ms")
+        final_offset_ms = measurements[0] + global_shift_ms
+
+    else:
+        # Multiple measurements - check agreement
+        median_offset = sorted(measurements)[len(measurements) // 2]
+        max_deviation = max(abs(m - median_offset) for m in measurements)
+
+        runner._log_message(f"[SubAnchor FrameSnap] Measurements: {[f'{m:+.1f}ms' for m in measurements]}")
+        runner._log_message(f"[SubAnchor FrameSnap] Median: {median_offset:+.3f}ms")
+        runner._log_message(f"[SubAnchor FrameSnap] Max deviation: {max_deviation:.1f}ms")
+
+        if max_deviation <= tolerance_ms:
+            runner._log_message(f"[SubAnchor FrameSnap] ✓ Checkpoints AGREE within ±{tolerance_ms}ms")
+            final_offset_ms = median_offset + global_shift_ms
+        else:
+            runner._log_message(f"[SubAnchor FrameSnap] ⚠ Checkpoints DISAGREE (max deviation: {max_deviation:.1f}ms > {tolerance_ms}ms)")
+
+            if fallback_mode == 'abort':
+                return {
+                    'success': False,
+                    'error': f'Checkpoints disagree: max deviation {max_deviation:.1f}ms > {tolerance_ms}ms tolerance',
+                    'measurements': measurements,
+                    'checkpoints': checkpoint_details
+                }
+            else:
+                # Use median anyway
+                runner._log_message(f"[SubAnchor FrameSnap] Fallback: Using median offset anyway")
+                final_offset_ms = median_offset + global_shift_ms
+
+    runner._log_message(f"[SubAnchor FrameSnap] ───────────────────────────────────────")
+    runner._log_message(f"[SubAnchor FrameSnap] Final offset calculation:")
+    if len(measurements) > 0:
+        runner._log_message(f"[SubAnchor FrameSnap]   Frame match offset: {measurements[0] if len(measurements) == 1 else median_offset:+.3f}ms")
+    runner._log_message(f"[SubAnchor FrameSnap]   + Global shift:      {global_shift_ms:+.3f}ms")
+    runner._log_message(f"[SubAnchor FrameSnap]   ─────────────────────────────────────")
+    runner._log_message(f"[SubAnchor FrameSnap]   = FINAL offset:      {final_offset_ms:+.3f}ms")
+
+    # Capture original metadata
+    metadata = SubtitleMetadata(subtitle_path)
+    metadata.capture()
+
+    # Apply offset to all subtitle events using FLOOR for final rounding
+    final_offset_int = int(math.floor(final_offset_ms))
+    runner._log_message(f"[SubAnchor FrameSnap] Applying offset to {len(subs.events)} events (floor: {final_offset_int}ms)")
+
+    for event in subs.events:
+        event.start += final_offset_int
+        event.end += final_offset_int
+
+    # Save modified subtitle
+    runner._log_message(f"[SubAnchor FrameSnap] Saving modified subtitle file...")
+    try:
+        subs.save(subtitle_path, encoding='utf-8')
+    except Exception as e:
+        runner._log_message(f"[SubAnchor FrameSnap] ERROR: Failed to save subtitle file: {e}")
+        return {
+            'success': False,
+            'error': f'Failed to save subtitle file: {e}',
+            'checkpoints': checkpoint_details
+        }
+
+    # Validate and restore metadata
+    metadata.validate_and_restore(runner, expected_delay_ms=final_offset_int)
+
+    runner._log_message(f"[SubAnchor FrameSnap] Successfully synchronized {len(subs.events)} events")
+    runner._log_message(f"[SubAnchor FrameSnap] ═══════════════════════════════════════")
+
+    verification_result = {
+        'valid': len(measurements) >= 2 and max_deviation <= tolerance_ms if len(measurements) >= 2 else len(measurements) == 1,
+        'num_checkpoints_matched': len(measurements),
+        'num_checkpoints_total': len(checkpoints),
+        'max_deviation_ms': max_deviation if len(measurements) >= 2 else 0,
+        'measurements': measurements
+    }
+
+    return {
+        'success': True,
+        'total_events': len(subs.events),
+        'final_offset_ms': final_offset_ms,
+        'final_offset_applied': final_offset_int,
+        'global_shift_ms': global_shift_ms,
+        'frame_match_offset_ms': median_offset if len(measurements) >= 2 else (measurements[0] if measurements else 0),
+        'source_fps': source_fps,
+        'target_fps': target_fps,
+        'frame_duration_ms': frame_duration_ms,
+        'checkpoints': checkpoint_details,
+        'verification': verification_result
+    }


### PR DESCRIPTION
New visual-only sync mode that uses subtitle positions as frame anchors instead of PySceneDetect scene changes. This addresses cases where:
- Audio correlation fails or is unavailable
- Scene detection picks bad frames (black, transitions, title cards)
- Duration-aligned dHash matching works but correlation mode doesn't

Key features:
- Uses dialogue events as anchor points (stable, content-rich frames)
- Sliding window frame matching with temporal consistency (11 frames)
- Sub-frame timing precision preserved until final floor rounding
- Configurable search range (±ms), hash algorithm, threshold, tolerance
- Fallback modes: abort (default) or use-median
- No dependency on audio correlation - purely visual matching

Files changed:
- vsg_core/subtitles/frame_sync.py: New apply_subtitle_anchored_frame_snap_sync()
- vsg_core/config.py: Default settings for sub_anchor_* options
- vsg_qt/options_dialog/tabs.py: UI widgets and visibility handling
- vsg_core/orchestrator/steps/subtitles_step.py: Mode handler