### PR TITLE
Fix FFMS2 index storage for Duration Align sync mode

### DIFF
--- a/vsg_core/orchestrator/steps/subtitles_step.py
+++ b/vsg_core/orchestrator/steps/subtitles_step.py
@@ -276,7 +276,8 @@ class SubtitlesStep:
                                     str(target_video),
                                     global_shift_ms,
                                     runner,
-                                    sync_config
+                                    sync_config,
+                                    ctx.temp_dir
                                 )
 
                                 if frame_sync_report and 'error' not in frame_sync_report:


### PR DESCRIPTION
Problem:
Duration Align sync mode was saving FFMS2 indexes next to the original video files, even after previous commits fixed this for SubAnchor Frame Snap mode. This happened because frame_sync.py (used by Duration Align) wasn't updated to use custom cache paths.

Previous fix applied only to frame_matching.py (SubAnchor Frame Snap), but frame_sync.py still called:
  core.ffms2.Source(str(video_path))
Without cachefile parameter, VapourSynth defaults to saving index next to video file.

Solution:
1. Added _get_ffms2_cache_path() helper to frame_sync.py
   - Same logic as frame_matching.py
   - Uses parent_dir + filename + size + mtime for unique cache key
   - Stores in job_temp/ffindex/ folder

2. Updated get_vapoursynth_frame_info() to:
   - Accept temp_dir parameter
   - Use cachefile parameter in core.ffms2.Source()
   - Log index location (job_temp/ffindex/...)

3. Updated extract_frame_as_image() similarly
   - Accept temp_dir parameter
   - Use cachefile parameter for FFMS2

4. Updated apply_duration_align_sync() to:
   - Accept temp_dir parameter
   - Pass to get_vapoursynth_frame_info() calls

5. Updated validate_frame_alignment() to:
   - Accept temp_dir parameter
   - Pass to extract_frame_as_image() calls

6. Updated subtitles_step.py caller:
   - Pass ctx.temp_dir to apply_duration_align_sync()

Benefits:
- Indexes now stored in job temp folder (auto-cleanup)
- No more index pollution next to video files
- Consistent behavior across all sync modes
- Same collision-prevention logic (parent_dir in cache key)
- User can see index location in logs

Example log output:
[VapourSynth] ✓ Reusing existing index from: job_temp/ffindex/source1_1_123456_789.ffindex