### PR TITLE
Fix analyze-only multi-correlation checkbox not being respected

### DIFF
--- a/vsg_core/analysis/audio_corr.py
+++ b/vsg_core/analysis/audio_corr.py
@@ -556,6 +556,12 @@ def run_multi_correlation(
     """
     log = runner._log_message
 
+    # Safety check: if multi-correlation is disabled, fall back to single method immediately
+    if not config.get('multi_correlation_enabled', False):
+        log("[MULTI-CORRELATION] Feature disabled, using single correlation method")
+        return {config.get('correlation_method', 'Standard Correlation (SCC)'):
+                run_audio_correlation(ref_file, target_file, config, runner, tool_paths, ref_lang, target_lang, role_tag)}
+
     # Get enabled methods
     enabled_methods = []
     for method_name, config_key in MULTI_CORR_METHODS:

--- a/vsg_core/orchestrator/steps/analysis_step.py
+++ b/vsg_core/orchestrator/steps/analysis_step.py
@@ -356,7 +356,7 @@ class AnalysisStep:
                 continue
 
             # Check if multi-correlation comparison is enabled (Analyze Only mode only)
-            multi_corr_enabled = config.get('multi_correlation_enabled', False) and not ctx.and_merge
+            multi_corr_enabled = bool(config.get('multi_correlation_enabled', False)) and (not ctx.and_merge)
 
             if multi_corr_enabled:
                 # Run multiple correlation methods for comparison


### PR DESCRIPTION
Fixed bug where unchecking "Enable Multi-Correlation Comparison" would still run multi-correlation instead of respecting the normal Correlation Method dropdown selection.

Root cause: Individual method checkboxes (multi_corr_scc, etc.) remain True in config when main checkbox is unchecked (they're just hidden, not disabled). This caused run_multi_correlation to run even when the feature should be disabled.

Changes:
- Made boolean check more explicit in analysis_step.py
- Added safety check at start of run_multi_correlation() to immediately fall back to single method if feature is disabled
- Ensures dropdown selection is always respected when checkbox is unchecked

Fixes issue where Analyze Only mode would give incorrect results when multi-correlation was disabled.