### PR TITLE
Wire correlation-guided-frame-anchor sync mode to orchestrator

### DIFF
--- a/vsg_core/orchestrator/steps/subtitles_step.py
+++ b/vsg_core/orchestrator/steps/subtitles_step.py
@@ -17,7 +17,7 @@ from vsg_core.subtitles.ocr import run_ocr
 from vsg_core.subtitles.cleanup import run_cleanup
 from vsg_core.subtitles.timing import fix_subtitle_timing
 from vsg_core.subtitles.stepping_adjust import apply_stepping_to_subtitles
-from vsg_core.subtitles.frame_sync import apply_raw_delay_sync, apply_duration_align_sync, apply_correlation_frame_snap_sync, apply_subtitle_anchored_frame_snap_sync
+from vsg_core.subtitles.frame_sync import apply_raw_delay_sync, apply_duration_align_sync, apply_correlation_frame_snap_sync, apply_subtitle_anchored_frame_snap_sync, apply_correlation_guided_frame_anchor_sync
 
 class SubtitlesStep:
     def run(self, ctx: Context, runner: CommandRunner) -> Context:
@@ -240,7 +240,7 @@ class SubtitlesStep:
                             runner._log_message(f"[Time-Based Raw] Skipping track {item.track.id} - format {ext} not supported")
                     # else: default time-based mode uses mkvmerge --sync, no processing needed here
 
-                elif subtitle_sync_mode in ['duration-align', 'correlation-frame-snap', 'subtitle-anchored-frame-snap']:
+                elif subtitle_sync_mode in ['duration-align', 'correlation-frame-snap', 'subtitle-anchored-frame-snap', 'correlation-guided-frame-anchor']:
                     # Check if this subtitle format supports advanced sync
                     ext = item.extracted_path.suffix.lower()
                     supported_formats = ['.ass', '.ssa', '.srt', '.vtt']
@@ -448,6 +448,63 @@ class SubtitlesStep:
                                 runner._log_message(f"[SubAnchor FrameSnap] ERROR: Missing source or target video")
                                 runner._log_message(f"[SubAnchor FrameSnap] Source: {source_video}, Target: {target_video}")
                                 raise RuntimeError(f"SubAnchor FrameSnap sync failed: missing source/target video")
+
+                        # Correlation-Guided Frame Anchor mode: Hybrid sync using correlation + frame anchors
+                        if subtitle_sync_mode == 'correlation-guided-frame-anchor':
+                            # Requires source and target videos + correlation delay
+                            source_key = item.sync_to if item.track.source == 'External' else item.track.source
+                            source_video = ctx.sources.get(source_key)
+                            target_video = source1_file
+
+                            # Get total delay (already includes global_shift)
+                            total_delay_with_global_ms = 0.0
+                            if ctx.delays and source_key in ctx.delays.raw_source_delays_ms:
+                                total_delay_with_global_ms = ctx.delays.raw_source_delays_ms[source_key]
+                                runner._log_message(f"[CorrGuidedAnchor] Total delay (with global): {total_delay_with_global_ms:+.3f}ms from {source_key}")
+
+                            # Get raw global shift separately for logging breakdown
+                            raw_global_shift_ms = 0.0
+                            if ctx.delays:
+                                raw_global_shift_ms = ctx.delays.raw_global_shift_ms
+                                runner._log_message(f"[CorrGuidedAnchor] Global shift: {raw_global_shift_ms:+.3f}ms")
+
+                            if source_video and target_video:
+                                runner._log_message(f"[CorrGuidedAnchor] Applying to track {item.track.id} ({item.track.props.name or 'Unnamed'})")
+                                runner._log_message(f"[CorrGuidedAnchor] Source video: {Path(source_video).name}")
+                                runner._log_message(f"[CorrGuidedAnchor] Target video: {Path(target_video).name}")
+
+                                frame_sync_report = apply_correlation_guided_frame_anchor_sync(
+                                    str(item.extracted_path),
+                                    str(source_video),
+                                    str(target_video),
+                                    total_delay_with_global_ms,
+                                    raw_global_shift_ms,
+                                    runner,
+                                    ctx.settings_dict,
+                                    temp_dir=ctx.temp_dir
+                                )
+
+                                if frame_sync_report and frame_sync_report.get('success'):
+                                    runner._log_message(f"--- Correlation-Guided Frame Anchor Sync Report ---")
+                                    for key, value in frame_sync_report.items():
+                                        if key not in ('verification', 'checkpoints'):  # Skip nested dicts
+                                            runner._log_message(f"  - {key.replace('_', ' ').title()}: {value}")
+                                    runner._log_message("------------------------------------------")
+                                    # Mark that timestamps have been adjusted
+                                    item.frame_adjusted = True
+                                elif frame_sync_report and 'error' in frame_sync_report:
+                                    # Sync function returned error
+                                    error_msg = frame_sync_report['error']
+                                    runner._log_message(f"[CorrGuidedAnchor] ERROR: Sync failed for track {item.track.id}: {error_msg}")
+                                    raise RuntimeError(f"Correlation-Guided Frame Anchor sync failed for track {item.track.id}: {error_msg}")
+                                else:
+                                    # No report or unexpected result
+                                    runner._log_message(f"[CorrGuidedAnchor] ERROR: No sync report returned for track {item.track.id}")
+                                    raise RuntimeError(f"Correlation-Guided Frame Anchor sync failed for track {item.track.id}: No report returned")
+                            else:
+                                runner._log_message(f"[CorrGuidedAnchor] ERROR: Missing source or target video")
+                                runner._log_message(f"[CorrGuidedAnchor] Source: {source_video}, Target: {target_video}")
+                                raise RuntimeError(f"Correlation-Guided Frame Anchor sync failed: missing source/target video")
 
                     else:
                         # Unsupported format (PGS/VOB bitmap subtitles)


### PR DESCRIPTION
The correlation-guided-frame-anchor mode was previously implemented with UI controls but was never wired into the orchestrator's execution logic. This commit completes the integration by:

1. Adding import for apply_correlation_guided_frame_anchor_sync
2. Adding mode to elif condition for frame-based sync modes
3. Adding execution branch with proper error handling

The mode now executes when selected in the UI, using correlation delay as baseline guidance and frame anchors at 10%, 50%, 90% of video duration.