### PR TITLE
Add frame sync style exclusions for anchor mode

### DIFF
--- a/vsg_core/models/jobs.py
+++ b/vsg_core/models/jobs.py
@@ -52,6 +52,11 @@ class PlanItem:
     generated_verify_only_lines_removed: bool = True  # Verify only event lines removed, nothing else changed
     skip_frame_validation: bool = False  # Skip duration-align frame validation (for generated tracks)
 
+    # Sync exclusion fields (for excluding styles from frame matching in anchor mode)
+    sync_exclusion_styles: List[str] = field(default_factory=list)  # Style names to exclude/include from frame sync
+    sync_exclusion_mode: str = 'exclude'  # 'exclude' or 'include' styles
+    sync_exclusion_original_style_list: List[str] = field(default_factory=list)  # Complete style list for validation
+
 @dataclass(frozen=True)
 class MergePlan:
     items: list[PlanItem]

--- a/vsg_core/orchestrator/steps/subtitles_step.py
+++ b/vsg_core/orchestrator/steps/subtitles_step.py
@@ -481,7 +481,9 @@ class SubtitlesStep:
                                     raw_global_shift_ms,
                                     runner,
                                     ctx.settings_dict,
-                                    temp_dir=ctx.temp_dir
+                                    temp_dir=ctx.temp_dir,
+                                    sync_exclusion_styles=item.sync_exclusion_styles,
+                                    sync_exclusion_mode=item.sync_exclusion_mode
                                 )
 
                                 if frame_sync_report and frame_sync_report.get('success'):

--- a/vsg_qt/sync_exclusion_dialog/__init__.py
+++ b/vsg_qt/sync_exclusion_dialog/__init__.py
@@ -1,0 +1,8 @@
+# vsg_qt/sync_exclusion_dialog/__init__.py
+# -*- coding: utf-8 -*-
+"""
+Dialog for configuring frame sync style exclusions.
+"""
+from .ui import SyncExclusionDialog
+
+__all__ = ['SyncExclusionDialog']

--- a/vsg_qt/sync_exclusion_dialog/ui.py
+++ b/vsg_qt/sync_exclusion_dialog/ui.py
@@ -1,0 +1,252 @@
+# vsg_qt/sync_exclusion_dialog/ui.py
+# -*- coding: utf-8 -*-
+"""
+Dialog for configuring frame sync style exclusions.
+"""
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
+    QDialogButtonBox, QListWidget, QListWidgetItem,
+    QCheckBox, QGroupBox, QRadioButton, QButtonGroup
+)
+
+from vsg_core.subtitles.style_filter import StyleFilterEngine
+
+
+class SyncExclusionDialog(QDialog):
+    """
+    Dialog for selecting which subtitle styles to exclude from frame matching
+    in anchor mode (they will use corrected offset instead).
+    """
+
+    def __init__(self, track_data: dict, existing_config: dict = None, parent=None):
+        super().__init__(parent)
+        self.track_data = track_data
+        self.existing_config = existing_config  # For editing existing exclusions
+        self.exclusion_config = None  # Will be set if user clicks OK
+        self.style_counts = {}
+        self.style_checkboxes = {}
+
+        self.setWindowTitle("Configure Frame Sync Style Exclusions")
+        self.setMinimumSize(500, 600)
+
+        self._build_ui()
+        self._load_styles()
+        self._apply_existing_config()  # Apply existing settings if editing
+        self._update_preview()
+
+    def _build_ui(self):
+        """Build the dialog UI."""
+        layout = QVBoxLayout(self)
+
+        # Info label
+        info_text = (
+            f"Configure which styles to exclude from frame matching:\n"
+            f"Source: {self.track_data.get('source', 'Unknown')}\n"
+            f"Track ID: {self.track_data.get('id', 'N/A')}\n"
+            f"Description: {self.track_data.get('description', 'N/A')}"
+        )
+        info_label = QLabel(info_text)
+        info_label.setStyleSheet("font-weight: bold; padding: 10px; background-color: #f0f0f0; color: #000000;")
+        layout.addWidget(info_label)
+
+        # Explanation
+        help_text = (
+            "Excluded styles will use the corrected offset instead of frame matching.\n"
+            "This is useful for signs, effects, or other styles that shouldn't be frame-aligned."
+        )
+        help_label = QLabel(help_text)
+        help_label.setWordWrap(True)
+        help_label.setStyleSheet("padding: 10px; background-color: #ffffcc; color: #000000;")
+        layout.addWidget(help_label)
+
+        # Filter mode selection
+        mode_group = QGroupBox("Exclusion Mode")
+        mode_layout = QVBoxLayout(mode_group)
+
+        self.mode_button_group = QButtonGroup(self)
+        self.exclude_radio = QRadioButton("Exclude selected styles from frame sync (use corrected offset)")
+        self.include_radio = QRadioButton("Include only selected styles for frame sync (exclude others)")
+        self.exclude_radio.setChecked(True)  # Default to exclude mode
+
+        self.mode_button_group.addButton(self.exclude_radio)
+        self.mode_button_group.addButton(self.include_radio)
+
+        mode_layout.addWidget(self.exclude_radio)
+        mode_layout.addWidget(self.include_radio)
+        layout.addWidget(mode_group)
+
+        # Connect mode change to preview update
+        self.exclude_radio.toggled.connect(self._update_preview)
+
+        # Style selection list
+        styles_group = QGroupBox("Select Styles")
+        styles_layout = QVBoxLayout(styles_group)
+
+        help_label = QLabel("Check the styles you want to exclude/include from frame sync:")
+        help_label.setWordWrap(True)
+        styles_layout.addWidget(help_label)
+
+        self.styles_list = QListWidget()
+        styles_layout.addWidget(self.styles_list)
+
+        # Select All / Deselect All buttons
+        btn_layout = QHBoxLayout()
+        self.select_all_btn = QPushButton("Select All")
+        self.deselect_all_btn = QPushButton("Deselect All")
+        self.select_all_btn.clicked.connect(self._select_all_styles)
+        self.deselect_all_btn.clicked.connect(self._deselect_all_styles)
+        btn_layout.addWidget(self.select_all_btn)
+        btn_layout.addWidget(self.deselect_all_btn)
+        styles_layout.addLayout(btn_layout)
+
+        layout.addWidget(styles_group)
+
+        # Preview label
+        self.preview_label = QLabel()
+        self.preview_label.setStyleSheet("font-weight: bold; padding: 10px;")
+        self.preview_label.setWordWrap(True)
+        layout.addWidget(self.preview_label)
+
+        # Dialog buttons
+        button_box = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        button_box.accepted.connect(self._on_accept)
+        button_box.rejected.connect(self.reject)
+        layout.addWidget(button_box)
+
+    def _load_styles(self):
+        """Load available styles from the subtitle file."""
+        # Try to get the path from various possible locations
+        subtitle_path = (
+            self.track_data.get('original_path') or
+            self.track_data.get('user_modified_path') or
+            self.track_data.get('extracted_path')
+        )
+
+        if not subtitle_path:
+            self.preview_label.setText("Error: No subtitle file path found")
+            return
+
+        try:
+            # Get style counts from the filter engine
+            self.style_counts = StyleFilterEngine.get_styles_from_file(subtitle_path)
+
+            if not self.style_counts:
+                self.preview_label.setText("⚠️ No styles found in subtitle file")
+                self.preview_label.setStyleSheet("font-weight: bold; padding: 10px; color: #FFA500;")
+                return
+
+            # Add checkboxes for each style
+            for style_name, count in sorted(self.style_counts.items()):
+                item = QListWidgetItem(self.styles_list)
+                checkbox = QCheckBox(f"{style_name} ({count} events)")
+                checkbox.stateChanged.connect(self._update_preview)
+                self.styles_list.addItem(item)
+                self.styles_list.setItemWidget(item, checkbox)
+                self.style_checkboxes[style_name] = checkbox
+
+        except Exception as e:
+            self.preview_label.setText(f"❌ Error loading styles:\n{str(e)}")
+            self.preview_label.setStyleSheet("font-weight: bold; padding: 10px; color: #FF0000;")
+
+    def _apply_existing_config(self):
+        """Apply existing configuration when editing exclusions."""
+        if not self.existing_config:
+            return
+
+        # Set the exclusion mode
+        mode = self.existing_config.get('mode', 'exclude')
+        if mode == 'include':
+            self.include_radio.setChecked(True)
+        else:
+            self.exclude_radio.setChecked(True)
+
+        # Check the previously selected styles
+        selected_styles = self.existing_config.get('styles', [])
+        for style_name in selected_styles:
+            if style_name in self.style_checkboxes:
+                self.style_checkboxes[style_name].setChecked(True)
+
+    def _select_all_styles(self):
+        """Check all style checkboxes."""
+        for checkbox in self.style_checkboxes.values():
+            checkbox.setChecked(True)
+
+    def _deselect_all_styles(self):
+        """Uncheck all style checkboxes."""
+        for checkbox in self.style_checkboxes.values():
+            checkbox.setChecked(False)
+
+    def _get_selected_styles(self):
+        """Get list of currently selected style names."""
+        return [
+            style_name for style_name, checkbox in self.style_checkboxes.items()
+            if checkbox.isChecked()
+        ]
+
+    def _update_preview(self):
+        """Update the preview label showing what will be excluded from frame sync."""
+        selected_styles = self._get_selected_styles()
+        mode = 'exclude' if self.exclude_radio.isChecked() else 'include'
+
+        if not selected_styles:
+            self.preview_label.setText("⚠️ No styles selected - all events will be frame-matched normally")
+            self.preview_label.setStyleSheet("font-weight: bold; padding: 10px; color: #FFA500;")
+            return
+
+        total_events = sum(self.style_counts.values())
+        selected_events = sum(self.style_counts.get(s, 0) for s in selected_styles)
+
+        if mode == 'exclude':
+            frame_matched = total_events - selected_events
+            corrected_only = selected_events
+            preview_text = (
+                f"⚡ {corrected_only} events will use corrected offset only (no frame matching)\n"
+                f"✓ {frame_matched} events will be frame-matched normally\n"
+                f"Excluded styles: {', '.join(selected_styles)}"
+            )
+        else:  # include
+            frame_matched = selected_events
+            corrected_only = total_events - selected_events
+            preview_text = (
+                f"✓ {frame_matched} events will be frame-matched normally from styles: {', '.join(selected_styles)}\n"
+                f"⚡ {corrected_only} events from other styles will use corrected offset only"
+            )
+
+        self.preview_label.setText(preview_text)
+        self.preview_label.setStyleSheet("font-weight: bold; padding: 10px; color: #00AA00;")
+
+    def _on_accept(self):
+        """Validate and save the configuration when user clicks OK."""
+        selected_styles = self._get_selected_styles()
+
+        # Allow empty selection (means no exclusions)
+        if not selected_styles:
+            self.exclusion_config = None  # Clear exclusions
+            self.accept()
+            return
+
+        mode = 'exclude' if self.exclude_radio.isChecked() else 'include'
+
+        # Store both the selected styles AND the complete original style list
+        # The complete list is used for validation when pasting layouts
+        self.exclusion_config = {
+            'mode': mode,
+            'styles': selected_styles,
+            'original_style_list': sorted(self.style_counts.keys())  # Complete list for validation
+        }
+
+        self.accept()
+
+    def get_exclusion_config(self):
+        """
+        Get the exclusion configuration if dialog was accepted.
+
+        Returns:
+            dict or None: {
+                'mode': 'exclude'/'include',
+                'styles': [...],  # Selected styles to exclude from frame sync
+                'original_style_list': [...],  # Complete style list from source
+            } or None if no exclusions configured
+        """
+        return self.exclusion_config

--- a/vsg_qt/track_settings_dialog/logic.py
+++ b/vsg_qt/track_settings_dialog/logic.py
@@ -67,6 +67,13 @@ class TrackSettingsLogic:
             # Enable convert-to-ASS only for SRT tracks
             self.v.cb_convert.setEnabled("S_TEXT/UTF8" in codec_upper)
 
+            # Show sync exclusion button only for ASS/SSA tracks (they have styles)
+            is_ass_or_ssa = 'S_TEXT/ASS' in codec_upper or 'S_TEXT/SSA' in codec_upper
+            self.v.sync_exclusion_btn.setVisible(is_ass_or_ssa)
+        else:
+            # Hide sync exclusion button for non-subtitle tracks
+            self.v.sync_exclusion_btn.setVisible(False)
+
     def apply_initial_values(
         self,
         *,

--- a/vsg_qt/track_settings_dialog/ui.py
+++ b/vsg_qt/track_settings_dialog/ui.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 from PySide6.QtWidgets import (
     QDialog, QVBoxLayout, QDialogButtonBox,
-    QCheckBox, QDoubleSpinBox, QComboBox, QFormLayout, QGroupBox, QLineEdit
+    QCheckBox, QDoubleSpinBox, QComboBox, QFormLayout, QGroupBox, QLineEdit, QPushButton
 )
 from .logic import TrackSettingsLogic
 
 class TrackSettingsDialog(QDialog):
     """Small popup dialog to edit per-track options."""
-    def __init__(self, track_type: str, codec_id: str, **kwargs):
+    def __init__(self, track_type: str, codec_id: str, track_data: dict = None, **kwargs):
         super().__init__()
         self.setWindowTitle("Track Settings")
         self.setMinimumWidth(400)
+        self.track_data = track_data or {}
 
         # --- UI Elements ---
         # Language selector (for all track types)
@@ -30,6 +31,10 @@ class TrackSettingsDialog(QDialog):
         self.size_multiplier.setDecimals(2)
         self.size_multiplier.setPrefix("Size multiplier: ")
         self.size_multiplier.setSuffix("x")
+
+        # Frame sync exclusions button (ASS/SSA only)
+        self.sync_exclusion_btn = QPushButton("Configure Frame Sync Exclusions...")
+        self.sync_exclusion_btn.clicked.connect(self._open_sync_exclusion_dialog)
 
         # --- Logic ---
         self._logic = TrackSettingsLogic(self)
@@ -57,6 +62,7 @@ class TrackSettingsDialog(QDialog):
         subtitle_layout.addWidget(self.cb_convert)
         subtitle_layout.addWidget(self.cb_rescale)
         subtitle_layout.addWidget(self.size_multiplier)
+        subtitle_layout.addWidget(self.sync_exclusion_btn)
         layout.addWidget(self.subtitle_group)
 
         btns = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
@@ -68,6 +74,44 @@ class TrackSettingsDialog(QDialog):
         self._logic.apply_initial_values(**kwargs)
         self._logic.init_for_type_and_codec(track_type, codec_id)
 
+    def _open_sync_exclusion_dialog(self):
+        """Open the sync exclusion configuration dialog."""
+        from vsg_qt.sync_exclusion_dialog import SyncExclusionDialog
+
+        # Get existing config if available
+        existing_config = None
+        if self.track_data.get('sync_exclusion_styles'):
+            existing_config = {
+                'mode': self.track_data.get('sync_exclusion_mode', 'exclude'),
+                'styles': self.track_data.get('sync_exclusion_styles', []),
+            }
+
+        dialog = SyncExclusionDialog(
+            track_data=self.track_data,
+            existing_config=existing_config,
+            parent=self
+        )
+
+        if dialog.exec():
+            config = dialog.get_exclusion_config()
+            if config:
+                # Store in track_data temporarily (will be saved when main dialog is accepted)
+                self.track_data['sync_exclusion_styles'] = config['styles']
+                self.track_data['sync_exclusion_mode'] = config['mode']
+                self.track_data['sync_exclusion_original_style_list'] = config['original_style_list']
+            else:
+                # Clear exclusions if None returned
+                self.track_data.pop('sync_exclusion_styles', None)
+                self.track_data.pop('sync_exclusion_mode', None)
+                self.track_data.pop('sync_exclusion_original_style_list', None)
+
     def read_values(self) -> dict:
         """Public method to retrieve the dialog's current values."""
-        return self._logic.read_values()
+        values = self._logic.read_values()
+
+        # Include sync exclusion config in the returned values
+        values['sync_exclusion_styles'] = self.track_data.get('sync_exclusion_styles', [])
+        values['sync_exclusion_mode'] = self.track_data.get('sync_exclusion_mode', 'exclude')
+        values['sync_exclusion_original_style_list'] = self.track_data.get('sync_exclusion_original_style_list', [])
+
+        return values

--- a/vsg_qt/track_widget/logic.py
+++ b/vsg_qt/track_widget/logic.py
@@ -106,6 +106,15 @@ class TrackWidgetLogic:
             if abs(size_mult - 1.0) > 1e-6:
                 parts.append(f"{size_mult:.2f}x Size")
 
+            # Show sync exclusion details
+            sync_exclusion_styles = self.track_data.get('sync_exclusion_styles', [])
+            if sync_exclusion_styles:
+                sync_mode = self.track_data.get('sync_exclusion_mode', 'exclude')
+                styles_str = ', '.join(sync_exclusion_styles[:2])  # Show first 2 styles
+                if len(sync_exclusion_styles) > 2:
+                    styles_str += f" +{len(sync_exclusion_styles) - 2} more"
+                parts.append(f"⚡ {'Excluding' if sync_mode == 'exclude' else 'Including'} sync: {styles_str}")
+
         if not parts:
             self.v.source_label.setText("")
         else:
@@ -123,6 +132,11 @@ class TrackWidgetLogic:
             badges.append("Default")
         if self.track_data.get('type') == 'subtitles' and self.v.cb_forced.isChecked():
             badges.append("Forced")
+
+        # NEW: Add sync exclusion badge
+        if self.track_data.get('sync_exclusion_styles'):
+            badges.append("⚡ Sync Exclusions")
+
         if self.track_data.get('user_modified_path'):
             badges.append("Edited")
         elif self.track_data.get('style_patch'):
@@ -180,6 +194,11 @@ class TrackWidgetLogic:
             "generated_filter_styles": self.track_data.get('generated_filter_styles', []),
             "generated_original_style_list": self.track_data.get('generated_original_style_list', []),
             "generated_verify_only_lines_removed": self.track_data.get('generated_verify_only_lines_removed', True),
+
+            # NEW: Include sync exclusion fields
+            "sync_exclusion_styles": self.track_data.get('sync_exclusion_styles', []),
+            "sync_exclusion_mode": self.track_data.get('sync_exclusion_mode', 'exclude'),
+            "sync_exclusion_original_style_list": self.track_data.get('sync_exclusion_original_style_list', []),
         }
 
         return config

--- a/vsg_qt/track_widget/ui.py
+++ b/vsg_qt/track_widget/ui.py
@@ -93,6 +93,7 @@ class TrackWidget(QWidget):
         dialog = TrackSettingsDialog(
             track_type=self.track_type,
             codec_id=self.codec_id,
+            track_data=self.track_data,
             **current_config
         )
 
@@ -118,6 +119,18 @@ class TrackWidget(QWidget):
                 self.track_data['custom_name'] = custom_name
             elif 'custom_name' in self.track_data:
                 del self.track_data['custom_name']
+
+            # NEW: Store sync exclusion config in track_data
+            sync_exclusion_styles = new_config.get('sync_exclusion_styles', [])
+            if sync_exclusion_styles:
+                self.track_data['sync_exclusion_styles'] = sync_exclusion_styles
+                self.track_data['sync_exclusion_mode'] = new_config.get('sync_exclusion_mode', 'exclude')
+                self.track_data['sync_exclusion_original_style_list'] = new_config.get('sync_exclusion_original_style_list', [])
+            else:
+                # Clear sync exclusion fields if no styles selected
+                self.track_data.pop('sync_exclusion_styles', None)
+                self.track_data.pop('sync_exclusion_mode', None)
+                self.track_data.pop('sync_exclusion_original_style_list', None)
 
             self.logic.refresh_badges()
             self.logic.refresh_summary()


### PR DESCRIPTION
Implemented a new feature to exclude specific subtitle styles from frame matching in correlation-guided anchor mode. Excluded styles will use the corrected offset instead of frame-level alignment.

Key changes:
- Added sync_exclusion_styles, sync_exclusion_mode, and sync_exclusion_original_style_list fields to PlanItem
- Created SyncExclusionDialog for configuring which styles to exclude
- Added "Configure Frame Sync Exclusions" button to TrackSettingsDialog (visible only for ASS/SSA subtitle tracks)
- Updated TrackWidget to display sync exclusion badge and details
- Modified correlation_guided_frame_anchor.py to check style exclusions and route excluded events to fallback path (corrected offset only)
- Added copy/paste validation for sync exclusions similar to generated tracks validation
- Supports both sequential and parallel processing modes
- Compatible with generated tracks (can have both features on same track)

This allows users to exclude signs, effects, or other styles that shouldn't be frame-aligned, improving sync accuracy for dialogue-heavy content while preserving timing precision for sign tracks.