### PR TITLE
Fix import error: Add apply_timebase_frame_locked_sync to frame_sync.…

### DIFF
--- a/vsg_core/subtitles/frame_sync.py
+++ b/vsg_core/subtitles/frame_sync.py
@@ -44,6 +44,7 @@ from .checkpoint_selection import select_smart_checkpoints as _select_smart_chec
 # Re-export sync modes
 from .sync_modes import (
     apply_raw_delay_sync,
+    apply_timebase_frame_locked_sync,
     apply_duration_align_sync,
     verify_alignment_with_sliding_window,
     apply_correlation_frame_snap_sync,
@@ -81,6 +82,7 @@ __all__ = [
 
     # Sync modes
     'apply_raw_delay_sync',
+    'apply_timebase_frame_locked_sync',
     'apply_duration_align_sync',
     'verify_alignment_with_sliding_window',
     'apply_correlation_frame_snap_sync',


### PR DESCRIPTION
…py exports

The frame_sync.py module re-exports all sync mode functions for backward compatibility. Added the new apply_timebase_frame_locked_sync function to both the import statement and __all__ list.

This fixes the ImportError when trying to import the new sync mode function from vsg_core.subtitles.frame_sync.