### PR TITLE
Add FrameLocked stats to POST-MERGE FINAL AUDIT

### DIFF
--- a/vsg_core/orchestrator/steps/subtitles_step.py
+++ b/vsg_core/orchestrator/steps/subtitles_step.py
@@ -317,6 +317,8 @@ class SubtitlesStep:
                                 for key, value in frame_sync_report.items():
                                     runner._log_message(f"  - {key.replace('_', ' ').title()}: {value}")
                                 runner._log_message("------------------------------------------")
+                                # Store FrameLocked stats for final audit
+                                item.framelocked_stats = frame_sync_report
                                 # Mark that timestamps have been adjusted (so mux uses --sync 0:0)
                                 item.frame_adjusted = True
                             else:


### PR DESCRIPTION
Added reporting of actual final FrameLocked subtitle changes to the post-merge audit:

Changes:
- Store FrameLocked stats on each subtitle item during sync
- Added _audit_framelocked_stats() method to FinalAuditor
- Reports "Final Duration Changed" and "Final End Adjusted" stats
- Warns if any durations were unexpectedly modified
- Shows [OK] if all durations preserved correctly (zero-duration stayed zero)

Example audit output:
--- Auditing FrameLocked Subtitle Quality ---
[FrameLocked] Track 3:
  - Total Events: 1930
  - Final Duration Changed: 0
  - Final End Adjusted: 0 [OK] All durations preserved correctly (zero-duration effects stayed zero-duration)

This gives users immediate visibility into whether FrameLocked sync preserved durations as intended or if there were unexpected modifications that need review.