### PR TITLE
Refactor JobPipeline into modular components

### DIFF
--- a/vsg_core/pipeline.py
+++ b/vsg_core/pipeline.py
@@ -1,29 +1,53 @@
 # vsg_core/pipeline.py
 # -*- coding: utf-8 -*-
-import json
+"""
+Job pipeline orchestrator.
+
+Coordinates sync job execution using modular components for improved
+maintainability and testability.
+"""
+
 import shutil
-import time
-import logging
 from pathlib import Path
 from typing import List, Dict, Any, Callable, Optional
 
 from .io.runner import CommandRunner
-from .orchestrator.pipeline import Orchestrator
-from .postprocess import finalize_merged_file, check_if_rebasing_is_needed, FinalAuditor
+from .pipeline_components import (
+    ToolValidator,
+    LogManager,
+    OutputWriter,
+    SyncExecutor,
+    SyncPlanner,
+    ResultAuditor,
+)
+
 
 class JobPipeline:
-    def __init__(self, config: dict, log_callback: Callable[[str], None], progress_callback: Callable[[float], None]):
+    """
+    Orchestrates video sync job execution.
+
+    Coordinates tool validation, sync planning, merge execution, and output
+    validation using modular components.
+    """
+
+    def __init__(
+        self,
+        config: dict,
+        log_callback: Callable[[str], None],
+        progress_callback: Callable[[float], None]
+    ):
+        """
+        Initializes the job pipeline.
+
+        Args:
+            config: Configuration dictionary
+            log_callback: Callback for GUI log messages
+            progress_callback: Callback for progress updates
+        """
         self.config = config
         self.gui_log_callback = log_callback
         self.progress = progress_callback
         self.tool_paths = {}
-
-    def _find_required_tools(self):
-        for tool in ['ffmpeg', 'ffprobe', 'mkvmerge', 'mkvextract', 'mkvpropedit']:
-            self.tool_paths[tool] = shutil.which(tool)
-            if not self.tool_paths[tool]:
-                raise FileNotFoundError(f"Required tool '{tool}' not found in PATH.")
-        self.tool_paths['videodiff'] = shutil.which('videodiff')
 
     def run_job(
         self,
@@ -33,6 +57,28 @@ class JobPipeline:
         manual_layout: Optional[List[Dict]] = None,
         attachment_sources: Optional[List[str]] = None
     ) -> Dict[str, Any]:
+        """
+        Runs a complete sync job.
+
+        Args:
+            sources: Dictionary mapping source names to file paths
+            and_merge: Whether to perform merge (vs. analyze-only)
+            output_dir_str: Output directory path
+            manual_layout: Manual layout configuration
+            attachment_sources: List of attachment source paths
+
+        Returns:
+            Dictionary containing:
+            - status: 'Analyzed', 'Merged', or 'Failed'
+            - delays: Sync delays (if successful)
+            - output: Output file path (if merged)
+            - error: Error message (if failed)
+            - name: Job name
+            - issues: Number of audit issues found
+            - stepping_sources: Sources with stepping detected
+            - stepping_detected_disabled: Sources with stepping detection disabled
+        """
+        # --- 1. Input Validation ---
         source1_file = sources.get("Source 1")
         if not source1_file:
             raise ValueError("Job is missing Source 1 (Reference).")
@@ -40,47 +86,57 @@ class JobPipeline:
         output_dir = Path(output_dir_str)
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        log_path = output_dir / f"{Path(source1_file).stem}.log"
-        logger = logging.getLogger(f'job_{Path(source1_file).stem}')
-        logger.setLevel(logging.INFO)
-        for handler in logger.handlers[:]: logger.removeHandler(handler)
-        handler = logging.FileHandler(log_path, mode='w', encoding='utf-8')
-        handler.setFormatter(logging.Formatter('%(message)s'))
-        logger.addHandler(handler)
-        logger.propagate = False
+        job_name = Path(source1_file).stem
 
-        def log_to_all(message: str):
-            logger.info(message.strip())
-            self.gui_log_callback(message)
+        # --- 2. Setup Logging ---
+        logger, handler, log_to_all = LogManager.setup_job_log(
+            job_name, output_dir, self.gui_log_callback
+        )
 
         runner = CommandRunner(self.config, log_to_all)
 
+        # --- 3. Validate Tools ---
         try:
-            self._find_required_tools()
+            self.tool_paths = ToolValidator.validate_tools()
         except FileNotFoundError as e:
             log_to_all(f'[ERROR] {e}')
-            return {'status': 'Failed', 'error': str(e), 'name': Path(source1_file).name}
+            return {
+                'status': 'Failed',
+                'error': str(e),
+                'name': Path(source1_file).name
+            }
 
         log_to_all(f'=== Starting Job: {Path(source1_file).name} ===')
         self.progress(0.0)
 
+        # --- 4. Validate Merge Requirements ---
         if and_merge and manual_layout is None:
             err_msg = 'Manual layout required for merge.'
             log_to_all(f'[ERROR] {err_msg}')
-            return {'status': 'Failed', 'error': err_msg, 'name': Path(source1_file).name}
+            return {
+                'status': 'Failed',
+                'error': err_msg,
+                'name': Path(source1_file).name
+            }
 
         ctx_temp_dir: Optional[Path] = None
+
         try:
-            orch = Orchestrator()
-            ctx = orch.run(
-                settings_dict=self.config, tool_paths=self.tool_paths, log=log_to_all, progress=self.progress,
-                sources=sources, and_merge=and_merge,
+            # --- 5. Plan Sync ---
+            ctx = SyncPlanner.plan_sync(
+                config=self.config,
+                tool_paths=self.tool_paths,
+                log_callback=log_to_all,
+                progress_callback=self.progress,
+                sources=sources,
+                and_merge=and_merge,
                 output_dir=str(output_dir),
                 manual_layout=manual_layout or [],
                 attachment_sources=attachment_sources or []
             )
             ctx_temp_dir = getattr(ctx, 'temp_dir', None)
 
+            # --- 6. Return Early if Analysis Only ---
             if not and_merge:
                 log_to_all('--- Analysis Complete (No Merge) ---')
                 self.progress(1.0)
@@ -89,43 +145,49 @@ class JobPipeline:
                     'delays': ctx.delays.source_delays_ms if ctx.delays else {},
                     'name': Path(source1_file).name,
                     'issues': 0,
-                    'stepping_sources': getattr(ctx, 'stepping_sources', []),  # NEW
-                    'stepping_detected_disabled': getattr(ctx, 'stepping_detected_disabled', [])  # NEW
+                    'stepping_sources': getattr(ctx, 'stepping_sources', []),
+                    'stepping_detected_disabled': getattr(ctx, 'stepping_detected_disabled', [])
                 }
 
+            # --- 7. Validate Merge Tokens ---
             if not ctx.tokens:
                 raise RuntimeError('Internal error: mkvmerge tokens were not generated.')
 
-            final_output_path = output_dir / Path(source1_file).name
+            # --- 8. Prepare Output Paths ---
+            final_output_path = OutputWriter.prepare_output_path(output_dir, Path(source1_file).name)
             mkvmerge_output_path = ctx.temp_dir / f"temp_{final_output_path.name}"
 
+            # --- 9. Add Output Flag to Tokens ---
             ctx.tokens.insert(0, str(mkvmerge_output_path))
             ctx.tokens.insert(0, '--output')
 
-            opts_path = self._write_mkvmerge_opts(ctx.tokens, ctx.temp_dir, runner)
-            merge_ok = runner.run(['mkvmerge', f'@{opts_path}'], self.tool_paths) is not None
+            # --- 10. Write mkvmerge Options ---
+            opts_path = OutputWriter.write_mkvmerge_options(
+                ctx.tokens, ctx.temp_dir, self.config, runner
+            )
+
+            # --- 11. Execute Merge ---
+            merge_ok = SyncExecutor.execute_merge(opts_path, self.tool_paths, runner)
             if not merge_ok:
                 raise RuntimeError('mkvmerge execution failed.')
 
-            normalize_enabled = self.config.get('post_mux_normalize_timestamps', False)
-
-            if normalize_enabled and check_if_rebasing_is_needed(mkvmerge_output_path, runner, self.tool_paths):
-                finalize_merged_file(mkvmerge_output_path, final_output_path, runner, self.config, self.tool_paths)
-            else:
-                shutil.move(mkvmerge_output_path, final_output_path)
+            # --- 12. Finalize Output ---
+            SyncExecutor.finalize_output(
+                mkvmerge_output_path,
+                final_output_path,
+                self.config,
+                self.tool_paths,
+                runner
+            )
 
             log_to_all(f'[SUCCESS] Output file created: {final_output_path}')
 
-            # --- FINAL AUDIT STEP (MANDATORY) ---
-            log_to_all("--- Post-Merge: Running Final Audit ---")
-            issues = 0
-            try:
-                auditor = FinalAuditor(ctx, runner)
-                issues = auditor.run(final_output_path)
-            except Exception as audit_error:
-                log_to_all(f"[ERROR] Final audit step failed: {audit_error}")
-            # --- END ---
+            # --- 13. Audit Output ---
+            issues = ResultAuditor.audit_output(
+                final_output_path, ctx, runner, log_to_all
+            )
 
+            # --- 14. Success ---
             self.progress(1.0)
             return {
                 'status': 'Merged',
@@ -133,8 +195,8 @@ class JobPipeline:
                 'delays': ctx.delays.source_delays_ms if ctx.delays else {},
                 'name': Path(source1_file).name,
                 'issues': issues,
-                'stepping_sources': getattr(ctx, 'stepping_sources', []),  # NEW
-                'stepping_detected_disabled': getattr(ctx, 'stepping_detected_disabled', [])  # NEW
+                'stepping_sources': getattr(ctx, 'stepping_sources', []),
+                'stepping_detected_disabled': getattr(ctx, 'stepping_detected_disabled', [])
             }
 
         except Exception as e:
@@ -144,24 +206,13 @@ class JobPipeline:
                 'error': str(e),
                 'name': Path(source1_file).name,
                 'issues': 0,
-                'stepping_sources': [],  # NEW
-                'stepping_detected_disabled': []  # NEW
+                'stepping_sources': [],
+                'stepping_detected_disabled': []
             }
+
         finally:
+            # --- 15. Cleanup ---
             if ctx_temp_dir and ctx_temp_dir.exists():
                 shutil.rmtree(ctx_temp_dir, ignore_errors=True)
             log_to_all('=== Job Finished ===')
-            handler.close()
-            logger.removeHandler(handler)
-
-    def _write_mkvmerge_opts(self, tokens, temp_dir: Path, runner: CommandRunner) -> str:
-        opts_path = temp_dir / 'opts.json'
-        try:
-            opts_path.write_text(json.dumps(tokens, ensure_ascii=False), encoding='utf-8')
-            if self.config.get('log_show_options_json'):
-                runner._log_message('--- mkvmerge options (json) ---\n' + json.dumps(tokens, indent=2, ensure_ascii=False) + '\n-------------------------------')
-            if self.config.get('log_show_options_pretty'):
-                runner._log_message(f'--- mkvmerge options (pretty) ---\n' + ' \\\n  '.join(tokens) + '\n-------------------------------')
-            return str(opts_path)
-        except Exception as e:
-            raise IOError(f"Failed to write mkvmerge options file: {e}")
+            LogManager.cleanup_log(logger, handler)

--- a/vsg_core/pipeline_components/__init__.py
+++ b/vsg_core/pipeline_components/__init__.py
@@ -1,0 +1,23 @@
+# vsg_core/pipeline_components/__init__.py
+# -*- coding: utf-8 -*-
+"""
+Pipeline components for modular job execution.
+
+Splits JobPipeline responsibilities into focused, testable components.
+"""
+
+from .tool_validator import ToolValidator
+from .log_manager import LogManager
+from .output_writer import OutputWriter
+from .sync_executor import SyncExecutor
+from .sync_planner import SyncPlanner
+from .result_auditor import ResultAuditor
+
+__all__ = [
+    'ToolValidator',
+    'LogManager',
+    'OutputWriter',
+    'SyncExecutor',
+    'SyncPlanner',
+    'ResultAuditor',
+]

--- a/vsg_core/pipeline_components/log_manager.py
+++ b/vsg_core/pipeline_components/log_manager.py
@@ -1,0 +1,68 @@
+# vsg_core/pipeline_components/log_manager.py
+# -*- coding: utf-8 -*-
+"""
+Log management component.
+
+Handles logger setup, file handlers, and log output routing.
+"""
+
+import logging
+from pathlib import Path
+from typing import Callable, Tuple
+
+
+class LogManager:
+    """Manages logging setup and cleanup for jobs."""
+
+    @staticmethod
+    def setup_job_log(
+        job_name: str,
+        log_dir: Path,
+        gui_log_callback: Callable[[str], None]
+    ) -> Tuple[logging.Logger, logging.FileHandler, Callable[[str], None]]:
+        """
+        Sets up logging for a job.
+
+        Args:
+            job_name: Name of the job (used for log filename and logger name)
+            log_dir: Directory where log file will be created
+            gui_log_callback: Callback to send log messages to GUI
+
+        Returns:
+            Tuple of (logger, handler, log_to_all_function)
+            - logger: Logger instance for this job
+            - handler: File handler (needed for cleanup)
+            - log_to_all: Function to log to both file and GUI
+        """
+        log_path = log_dir / f"{job_name}.log"
+        logger = logging.getLogger(f'job_{job_name}')
+        logger.setLevel(logging.INFO)
+
+        # Remove any existing handlers
+        for handler in logger.handlers[:]:
+            logger.removeHandler(handler)
+
+        # Create file handler
+        handler = logging.FileHandler(log_path, mode='w', encoding='utf-8')
+        handler.setFormatter(logging.Formatter('%(message)s'))
+        logger.addHandler(handler)
+        logger.propagate = False
+
+        # Create unified log function
+        def log_to_all(message: str):
+            logger.info(message.strip())
+            gui_log_callback(message)
+
+        return logger, handler, log_to_all
+
+    @staticmethod
+    def cleanup_log(logger: logging.Logger, handler: logging.FileHandler):
+        """
+        Cleans up logger and handler resources.
+
+        Args:
+            logger: Logger instance to clean up
+            handler: File handler to close
+        """
+        handler.close()
+        logger.removeHandler(handler)

--- a/vsg_core/pipeline_components/output_writer.py
+++ b/vsg_core/pipeline_components/output_writer.py
@@ -1,0 +1,78 @@
+# vsg_core/pipeline_components/output_writer.py
+# -*- coding: utf-8 -*-
+"""
+Output writer component.
+
+Handles writing mkvmerge options files and managing output paths.
+"""
+
+import json
+from pathlib import Path
+from typing import List
+
+from ..io.runner import CommandRunner
+
+
+class OutputWriter:
+    """Writes output files and mkvmerge configuration."""
+
+    @staticmethod
+    def write_mkvmerge_options(
+        tokens: List[str],
+        temp_dir: Path,
+        config: dict,
+        runner: CommandRunner
+    ) -> str:
+        """
+        Writes mkvmerge options to a JSON file.
+
+        Args:
+            tokens: List of mkvmerge command arguments
+            temp_dir: Temporary directory for options file
+            config: Configuration dictionary (for logging preferences)
+            runner: CommandRunner for logging
+
+        Returns:
+            Path to the written options file
+
+        Raises:
+            IOError: If writing the file fails
+        """
+        opts_path = temp_dir / 'opts.json'
+
+        try:
+            opts_path.write_text(json.dumps(tokens, ensure_ascii=False), encoding='utf-8')
+
+            # Optional logging
+            if config.get('log_show_options_json'):
+                runner._log_message(
+                    '--- mkvmerge options (json) ---\n' +
+                    json.dumps(tokens, indent=2, ensure_ascii=False) +
+                    '\n-------------------------------'
+                )
+
+            if config.get('log_show_options_pretty'):
+                runner._log_message(
+                    '--- mkvmerge options (pretty) ---\n' +
+                    ' \\\n  '.join(tokens) +
+                    '\n-------------------------------'
+                )
+
+            return str(opts_path)
+
+        except Exception as e:
+            raise IOError(f"Failed to write mkvmerge options file: {e}")
+
+    @staticmethod
+    def prepare_output_path(output_dir: Path, source1_filename: str) -> Path:
+        """
+        Prepares the final output path.
+
+        Args:
+            output_dir: Output directory
+            source1_filename: Name of the reference source file
+
+        Returns:
+            Path for the final output file
+        """
+        return output_dir / source1_filename

--- a/vsg_core/pipeline_components/result_auditor.py
+++ b/vsg_core/pipeline_components/result_auditor.py
@@ -1,0 +1,47 @@
+# vsg_core/pipeline_components/result_auditor.py
+# -*- coding: utf-8 -*-
+"""
+Result auditor component.
+
+Wraps the FinalAuditor for post-merge validation.
+"""
+
+from pathlib import Path
+from typing import Callable
+
+from ..io.runner import CommandRunner
+from ..postprocess import FinalAuditor
+
+
+class ResultAuditor:
+    """Audits merged output files for quality and correctness."""
+
+    @staticmethod
+    def audit_output(
+        output_file: Path,
+        context: object,
+        runner: CommandRunner,
+        log_callback: Callable[[str], None]
+    ) -> int:
+        """
+        Audits the merged output file.
+
+        Args:
+            output_file: Path to the merged output file
+            context: Context object from sync planning
+            runner: CommandRunner for execution
+            log_callback: Logging callback function
+
+        Returns:
+            Number of issues found (0 = no issues)
+        """
+        log_callback("--- Post-Merge: Running Final Audit ---")
+        issues = 0
+
+        try:
+            auditor = FinalAuditor(context, runner)
+            issues = auditor.run(output_file)
+        except Exception as audit_error:
+            log_callback(f"[ERROR] Final audit step failed: {audit_error}")
+
+        return issues

--- a/vsg_core/pipeline_components/sync_executor.py
+++ b/vsg_core/pipeline_components/sync_executor.py
@@ -1,0 +1,66 @@
+# vsg_core/pipeline_components/sync_executor.py
+# -*- coding: utf-8 -*-
+"""
+Sync executor component.
+
+Handles merge execution and post-processing finalization.
+"""
+
+import shutil
+from pathlib import Path
+from typing import Dict
+
+from ..io.runner import CommandRunner
+from ..postprocess import finalize_merged_file, check_if_rebasing_is_needed
+
+
+class SyncExecutor:
+    """Executes sync merges and finalizes output."""
+
+    @staticmethod
+    def execute_merge(
+        mkvmerge_options_path: str,
+        tool_paths: Dict[str, str],
+        runner: CommandRunner
+    ) -> bool:
+        """
+        Executes mkvmerge with the provided options file.
+
+        Args:
+            mkvmerge_options_path: Path to mkvmerge options JSON file
+            tool_paths: Dictionary of tool paths
+            runner: CommandRunner for execution
+
+        Returns:
+            True if merge succeeded, False otherwise
+        """
+        result = runner.run(['mkvmerge', f'@{mkvmerge_options_path}'], tool_paths)
+        return result is not None
+
+    @staticmethod
+    def finalize_output(
+        temp_output_path: Path,
+        final_output_path: Path,
+        config: dict,
+        tool_paths: Dict[str, str],
+        runner: CommandRunner
+    ):
+        """
+        Finalizes the merged output file.
+
+        Handles timestamp normalization if enabled and needed, otherwise
+        simply moves the file to its final location.
+
+        Args:
+            temp_output_path: Path to temporary merged file
+            final_output_path: Path to final output location
+            config: Configuration dictionary
+            tool_paths: Dictionary of tool paths
+            runner: CommandRunner for execution
+        """
+        normalize_enabled = config.get('post_mux_normalize_timestamps', False)
+
+        if normalize_enabled and check_if_rebasing_is_needed(temp_output_path, runner, tool_paths):
+            finalize_merged_file(temp_output_path, final_output_path, runner, config, tool_paths)
+        else:
+            shutil.move(temp_output_path, final_output_path)

--- a/vsg_core/pipeline_components/sync_planner.py
+++ b/vsg_core/pipeline_components/sync_planner.py
@@ -1,0 +1,64 @@
+# vsg_core/pipeline_components/sync_planner.py
+# -*- coding: utf-8 -*-
+"""
+Sync planner component.
+
+Wraps the Orchestrator to provide a cleaner interface for sync planning.
+"""
+
+from typing import Dict, List, Optional, Callable, Any
+
+from ..orchestrator.pipeline import Orchestrator
+
+
+class SyncPlanner:
+    """Plans sync operations by delegating to the Orchestrator."""
+
+    @staticmethod
+    def plan_sync(
+        config: dict,
+        tool_paths: Dict[str, str],
+        log_callback: Callable[[str], None],
+        progress_callback: Callable[[float], None],
+        sources: Dict[str, str],
+        and_merge: bool,
+        output_dir: str,
+        manual_layout: List[Dict],
+        attachment_sources: List[str]
+    ) -> Any:
+        """
+        Plans the sync operation by analyzing sources and preparing merge tokens.
+
+        This wraps the existing Orchestrator to provide a cleaner interface.
+
+        Args:
+            config: Configuration dictionary
+            tool_paths: Dictionary of tool paths
+            log_callback: Logging callback function
+            progress_callback: Progress callback function
+            sources: Dictionary mapping source names to file paths
+            and_merge: Whether to prepare for merging
+            output_dir: Output directory path
+            manual_layout: Manual layout configuration
+            attachment_sources: List of attachment source paths
+
+        Returns:
+            Context object containing:
+            - delays: Sync delays
+            - tokens: mkvmerge command tokens (if and_merge=True)
+            - temp_dir: Temporary directory
+            - stepping_sources: Sources with stepping detected
+            - stepping_detected_disabled: Sources with stepping detection disabled
+        """
+        orch = Orchestrator()
+        return orch.run(
+            settings_dict=config,
+            tool_paths=tool_paths,
+            log=log_callback,
+            progress=progress_callback,
+            sources=sources,
+            and_merge=and_merge,
+            output_dir=output_dir,
+            manual_layout=manual_layout,
+            attachment_sources=attachment_sources
+        )

--- a/vsg_core/pipeline_components/tool_validator.py
+++ b/vsg_core/pipeline_components/tool_validator.py
@@ -1,0 +1,42 @@
+# vsg_core/pipeline_components/tool_validator.py
+# -*- coding: utf-8 -*-
+"""
+Tool validation component.
+
+Validates that required external tools are available in the system PATH.
+"""
+
+import shutil
+from typing import Dict
+
+
+class ToolValidator:
+    """Validates and locates required external tools."""
+
+    REQUIRED_TOOLS = ['ffmpeg', 'ffprobe', 'mkvmerge', 'mkvextract', 'mkvpropedit']
+    OPTIONAL_TOOLS = ['videodiff']
+
+    @staticmethod
+    def validate_tools() -> Dict[str, str]:
+        """
+        Validates that all required tools are available in PATH.
+
+        Returns:
+            Dict mapping tool names to their paths
+
+        Raises:
+            FileNotFoundError: If any required tool is not found
+        """
+        tool_paths = {}
+
+        # Validate required tools
+        for tool in ToolValidator.REQUIRED_TOOLS:
+            tool_paths[tool] = shutil.which(tool)
+            if not tool_paths[tool]:
+                raise FileNotFoundError(f"Required tool '{tool}' not found in PATH.")
+
+        # Optional tools (don't fail if missing)
+        for tool in ToolValidator.OPTIONAL_TOOLS:
+            tool_paths[tool] = shutil.which(tool)
+
+        return tool_paths


### PR DESCRIPTION
Split JobPipeline's responsibilities into focused, testable components to reduce complexity and improve maintainability.

New components:
- ToolValidator: Validates required external tools
- LogManager: Handles logger setup and cleanup
- OutputWriter: Writes mkvmerge options files
- SyncExecutor: Executes merges and finalizes output
- SyncPlanner: Wraps Orchestrator for sync planning
- ResultAuditor: Wraps FinalAuditor for post-merge validation

Changes:
- Create vsg_core/pipeline_components/ directory with 6 new modules
- Refactor JobPipeline.run_job() to delegate to components
- Maintain identical public API (backwards compatible)
- Reduce run_job() from 126 lines to 137 lines but with clear separation of concerns and numbered steps
- Each component is independently testable

Benefits:
- Lower bug density (smaller, focused modules)
- Easier to test (each component can be unit tested)
- Easier to debug (clear boundaries between concerns)
- Easier to extend (add new components without touching others)