### PR TITLE
Remove build-system requirement - not needed for GUI app

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -87,7 +87,7 @@ The base installation includes everything needed for the app. However, if you wa
 ### For NVIDIA GPUs (CUDA):
 ```bash
 source Dependencies/.venv/bin/activate
-uv pip install -e ".[ai-audio-nvidia]"
+uv pip install torch demucs
 ```
 
 ### For AMD GPUs (ROCm):
@@ -102,7 +102,8 @@ uv pip install demucs
 ### For CPU only (slower):
 ```bash
 source Dependencies/.venv/bin/activate
-uv pip install -e ".[ai-audio-cpu]"
+# Install CPU-only PyTorch
+uv pip install torch demucs --index-url https://download.pytorch.org/whl/cpu
 ```
 
 **Note:** Torch + Demucs is a LARGE download (several GB). Only install if you need cross-language audio separation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,3 @@ ai-audio-cpu = [
 [tool.uv]
 # Use a local directory for the Python installation
 python-downloads = "manual"
-
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -65,8 +65,11 @@ echo ""
 echo -e "${YELLOW}[4/5] Installing dependencies...${NC}"
 echo "This will install all packages from pyproject.toml..."
 
-# Use uv pip to install the project and its dependencies
-uv pip install -e . --python "$VENV_DIR/bin/python"
+# Install dependencies directly (read from pyproject.toml)
+uv pip install \
+    PySide6 numpy scipy scikit-learn librosa pysubs2 pyenchant lxml av Pillow \
+    VideoTimestamps imagehash opencv-python ffms2 VapourSynth scenedetect webrtcvad-wheels \
+    --python "$VENV_DIR/bin/python"
 
 echo -e "${GREEN}✓ All dependencies installed${NC}"
 echo ""


### PR DESCRIPTION
Problem: Hatchling build error when installing as editable package
Solution: Install dependencies directly without building the project

Changes:
- Remove [build-system] from pyproject.toml (not needed for GUI apps)
- Update setup_env.sh to install dependencies directly with uv pip install
- Simplify optional dependency installation in SETUP.md

Why this works:
- GUI apps don't need to be installed as packages
- They run directly with "python main.py"
- We just need the dependencies, not the project as a package
- This is simpler and avoids build system complexity

The project structure (vsg_core/, vsg_qt/) works fine when Python is run from the project root directory.