### PR TITLE
Use conda only for Python, get all packages from pip

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -9,57 +9,71 @@ platforms = ["linux-64"]
 start = "python main.py"
 
 [dependencies]
+# Only Python from conda-forge - everything else from pip for latest versions
 python = ">=3.13,<3.14"
+pip = "*"
 
-# Core GUI Framework (conda-forge)
-pyside6 = "*"
+[pypi-dependencies]
+# All project dependencies from PyPI for latest versions and Python 3.13 compatibility
 
-# Scientific Computing & Analysis (conda-forge)
+# Core GUI Framework
+PySide6 = "*"
+
+# Scientific Computing & Analysis
 numpy = "*"
 scipy = "*"
 scikit-learn = "*"
 
-# Audio Analysis (conda-forge)
+# Audio Analysis - REQUIRED for correlation, onset detection, DTW, spectrogram analysis
 librosa = "*"
 numba = ">=0.61.0"
 llvmlite = ">=0.43.0"
 
-# XML Processing (conda-forge)
+# Subtitle Processing
+pysubs2 = "*"
+
+# Spell Checking
+pyenchant = "*"
+
+# XML Processing
 lxml = "*"
 
-# Video/Audio Processing (conda-forge)
+# Video/Audio Processing
 av = "*"
 
-# Image Processing (conda-forge)
-pillow = "*"
-opencv = "*"
+# Image Processing
+Pillow = "*"
 
-[pypi-dependencies]
-# Packages only available on PyPI
-pysubs2 = "*"
-pyenchant = "*"
-imagehash = "*"
-scenedetect = { version = "*", extras = ["opencv"] }
+# Frame/Video Timing
 VideoTimestamps = "*"
+
+# Frame Matching & Scene Detection
+imagehash = "*"
+opencv-python = "*"
 ffms2 = "*"
 VapourSynth = "*"
+scenedetect = { version = "*", extras = ["opencv"] }
+
+# Voice Activity Detection
 webrtcvad-wheels = "*"
 
-# Optional AI audio features (install with: pixi install -e ai-nvidia or pixi install -e ai-cpu)
-[feature.ai-nvidia.dependencies]
-pytorch = "*"
-pytorch-cuda = "*"
-
-[feature.ai-nvidia.pypi-dependencies]
+[feature.ai-rocm.pypi-dependencies]
+# AI audio separation for AMD GPUs with ROCm
+torch = { version = "*", index = "https://download.pytorch.org/whl/rocm6.2" }
 demucs = "*"
 
-[feature.ai-cpu.dependencies]
-pytorch = "*"
+[feature.ai-nvidia.pypi-dependencies]
+# AI audio separation for NVIDIA GPUs with CUDA
+torch = "*"
+demucs = "*"
 
 [feature.ai-cpu.pypi-dependencies]
+# AI audio separation CPU-only
+torch = "*"
 demucs = "*"
 
 [environments]
 default = { solve-group = "default" }
+ai-rocm = { features = ["ai-rocm"], solve-group = "default" }
 ai-nvidia = { features = ["ai-nvidia"], solve-group = "default" }
 ai-cpu = { features = ["ai-cpu"], solve-group = "default" }


### PR DESCRIPTION
- Keep only Python and pip from conda-forge
- Move all packages to pypi-dependencies for latest versions
- Remove pytorch-cuda dependencies causing resolution errors
- Add ai-rocm feature for AMD GPU support
- This ensures Python 3.13 compatibility and latest package versions

All packages now come from PyPI which has better Python 3.13 support and always provides the latest versions.