### PR TITLE
Remove solve-group to fix torch Python 3.13 compatibility error

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -57,9 +57,14 @@ scenedetect = { version = "*", extras = ["opencv"] }
 # Voice Activity Detection
 webrtcvad-wheels = "*"
 
+# Optional AI audio features - install separately if needed:
+# For AMD GPU:    pixi install -e ai-rocm
+# For NVIDIA GPU: pixi install -e ai-nvidia
+# For CPU only:   pixi install -e ai-cpu
+
 [feature.ai-rocm.pypi-dependencies]
 # AI audio separation for AMD GPUs with ROCm
-torch = { version = "*", index = "https://download.pytorch.org/whl/rocm6.2" }
+torch = "*"
 demucs = "*"
 
 [feature.ai-nvidia.pypi-dependencies]
@@ -73,7 +78,7 @@ torch = "*"
 demucs = "*"
 
 [environments]
-default = { solve-group = "default" }
-ai-rocm = { features = ["ai-rocm"], solve-group = "default" }
-ai-nvidia = { features = ["ai-nvidia"], solve-group = "default" }
-ai-cpu = { features = ["ai-cpu"], solve-group = "default" }
+# Each environment is independent - AI features won't interfere with default install
+ai-rocm = { features = ["ai-rocm"] }
+ai-nvidia = { features = ["ai-nvidia"] }
+ai-cpu = { features = ["ai-cpu"] }


### PR DESCRIPTION
- Remove solve-group from all environments to make them independent
- Remove custom ROCm index (use default PyPI torch)
- This prevents pixi from trying to solve AI features during default install
- AI features can be installed separately when needed

The solve-group was causing pixi to resolve all environments together, including ai-rocm with incompatible torch versions.