### PR TITLE
Default source separation to `auto`, improve ROCm detection, and silence startup diagnostics

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,17 +12,6 @@ from vsg_qt.main_window import MainWindow
 
 def main():
     """Initializes and runs the PyQt application."""
-    # Log GPU environment for debugging
-    try:
-        from vsg_core.system.gpu_env import log_gpu_environment
-        print("\n" + "="*60)
-        print("Video Sync GUI - Startup Diagnostics")
-        print("="*60)
-        log_gpu_environment(print)
-        print("="*60 + "\n")
-    except Exception as e:
-        print(f"[GPU] Warning: Could not detect GPU environment: {e}")
-
     app = QApplication(sys.argv)
     app.setApplicationName("Video Sync & Merge")
     window = MainWindow()

--- a/vsg_core/config.py
+++ b/vsg_core/config.py
@@ -132,7 +132,7 @@ class AppConfig:
 
             # --- Flexible Analysis Settings ---
             'source_separation_model': 'None (Use Original Audio)',
-            'source_separation_device': 'cpu',  # Device for source separation: 'cpu', 'cuda', 'mps'
+            'source_separation_device': 'auto',  # Device for source separation: 'auto', 'cpu', 'cuda', 'rocm', 'mps'
             'source_separation_timeout': 300,  # Timeout in seconds for source separation (0 = no timeout)
             'filtering_method': 'Dialogue Band-Pass Filter',
             'correlation_method': 'Phase Correlation (GCC-PHAT)',
@@ -363,7 +363,7 @@ class AppConfig:
 
         # Enum validation for specific keys
         if key == 'source_separation_device':
-            valid = ['cpu', 'cuda', 'mps']
+            valid = ['auto', 'cpu', 'cuda', 'rocm', 'mps']
             if value not in valid:
                 return False, f"{key} must be one of {valid}, got '{value}'"
 

--- a/vsg_core/system/gpu_env.py
+++ b/vsg_core/system/gpu_env.py
@@ -29,37 +29,45 @@ def detect_amd_gpu() -> Optional[Dict[str, str]]:
         )
 
         if result.returncode == 0:
-            gpu_name = result.stdout.strip()
+            gpu_name = None
+            for line in result.stdout.splitlines():
+                if 'Card Series' in line:
+                    gpu_name = line.split('Card Series', 1)[-1]
+                    gpu_name = gpu_name.split(':', 1)[-1].strip()
+                    break
+            if not gpu_name:
+                gpu_name = result.stdout.strip()
 
-            # Map common AMD GPUs to gfx architecture
-            gfx_map = {
-                'Radeon RX 7900': ('gfx1100', '11.0.0'),
-                'Radeon RX 7800': ('gfx1100', '11.0.0'),
-                'Radeon RX 7700': ('gfx1100', '11.0.0'),
-                'Radeon RX 7600': ('gfx1100', '11.0.0'),
-                'Radeon RX 6900': ('gfx1030', '10.3.0'),
-                'Radeon RX 6800': ('gfx1030', '10.3.0'),
-                'Radeon RX 6700': ('gfx1030', '10.3.0'),
-                'Radeon RX 6600': ('gfx1030', '10.3.0'),
-                'Radeon 890M': ('gfx1151', '11.5.1'),  # Strix Halo
-                'Radeon 780M': ('gfx1103', '11.0.3'),  # Phoenix
-            }
+            if gpu_name:
+                # Map common AMD GPUs to gfx architecture
+                gfx_map = {
+                    'Radeon RX 7900': ('gfx1100', '11.0.0'),
+                    'Radeon RX 7800': ('gfx1100', '11.0.0'),
+                    'Radeon RX 7700': ('gfx1100', '11.0.0'),
+                    'Radeon RX 7600': ('gfx1100', '11.0.0'),
+                    'Radeon RX 6900': ('gfx1030', '10.3.0'),
+                    'Radeon RX 6800': ('gfx1030', '10.3.0'),
+                    'Radeon RX 6700': ('gfx1030', '10.3.0'),
+                    'Radeon RX 6600': ('gfx1030', '10.3.0'),
+                    'Radeon 890M': ('gfx1151', '11.5.1'),  # Strix Halo
+                    'Radeon 780M': ('gfx1103', '11.0.3'),  # Phoenix
+                }
 
-            for pattern, (gfx, hsa) in gfx_map.items():
-                if pattern in gpu_name:
+                for pattern, (gfx, hsa) in gfx_map.items():
+                    if pattern in gpu_name:
+                        return {
+                            'name': gpu_name,
+                            'gfx_version': gfx,
+                            'hsa_version': hsa
+                        }
+
+                # Generic Radeon detection - use safe defaults
+                if 'Radeon' in gpu_name:
                     return {
                         'name': gpu_name,
-                        'gfx_version': gfx,
-                        'hsa_version': hsa
+                        'gfx_version': 'gfx1100',  # Most common modern AMD
+                        'hsa_version': '11.0.0'
                     }
-
-            # Generic Radeon detection - use safe defaults
-            if 'Radeon' in gpu_name:
-                return {
-                    'name': gpu_name,
-                    'gfx_version': 'gfx1100',  # Most common modern AMD
-                    'hsa_version': '11.0.0'
-                }
     except (FileNotFoundError, subprocess.TimeoutExpired):
         pass
 


### PR DESCRIPTION
### Motivation
- Allow Demucs/source-separation to prefer GPU when available by default instead of forcing CPU via `source_separation_device`.
- Make ROCm GPU detection more robust so the system can correctly identify AMD cards from `rocm-smi` output and set appropriate gfx/hsa values.
- Reduce noisy startup output from the GUI entrypoint and keep environment setup logic in the launcher.

### Description
- Change the default `source_separation_device` to `auto` and update validation to accept `auto` and `rocm` in addition to `cpu`, `cuda`, and `mps` in `vsg_core/config.py`.
- Improve `rocm-smi` output parsing in `vsg_core/system/gpu_env.py` by extracting `Card Series` lines and falling back to prudent defaults when a direct map is not found, preserving previous `lspci` fallback behavior.
- Remove the automatic GPU startup diagnostics printout from the GUI entrypoint by deleting the `log_gpu_environment` call in `main.py` so the launcher controls when and how GPU environment information is emitted.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696846d21728832fade3c6f59833e2c2)