### PR TITLE
Export AMDGPU ids paths from launcher and GPU env helper

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -71,6 +71,21 @@ setup_rocm_environment() {
         fi
     fi
 
+    if [ -z "$AMDGPU_IDS_PATH" ] || [ -z "$LIBDRM_AMDGPU_IDS_PATH" ]; then
+        AMDGPU_IDS_FILE=""
+        for candidate in "/opt/amdgpu/share/libdrm/amdgpu.ids" "/usr/share/libdrm/amdgpu.ids"; do
+            if [ -f "$candidate" ]; then
+                AMDGPU_IDS_FILE="$candidate"
+                break
+            fi
+        done
+        if [ -z "$AMDGPU_IDS_FILE" ]; then
+            AMDGPU_IDS_FILE="/dev/null"
+        fi
+        [ -z "$AMDGPU_IDS_PATH" ] && export AMDGPU_IDS_PATH="$AMDGPU_IDS_FILE"
+        [ -z "$LIBDRM_AMDGPU_IDS_PATH" ] && export LIBDRM_AMDGPU_IDS_PATH="$AMDGPU_IDS_FILE"
+    fi
+
     # Set ROCm environment variables if AMD GPU detected
     if [ "$AMD_GPU_DETECTED" = true ]; then
         [ -z "$ROCR_VISIBLE_DEVICES" ] && export ROCR_VISIBLE_DEVICES=0

--- a/vsg_core/system/gpu_env.py
+++ b/vsg_core/system/gpu_env.py
@@ -113,6 +113,23 @@ def get_rocm_environment() -> Dict[str, str]:
     """
     env = {}
 
+    if not os.environ.get('AMDGPU_IDS_PATH') or not os.environ.get('LIBDRM_AMDGPU_IDS_PATH'):
+        amdgpu_ids_path = None
+        for candidate in (
+            '/opt/amdgpu/share/libdrm/amdgpu.ids',
+            '/usr/share/libdrm/amdgpu.ids',
+        ):
+            if os.path.isfile(candidate):
+                amdgpu_ids_path = candidate
+                break
+        if not amdgpu_ids_path:
+            amdgpu_ids_path = '/dev/null'
+
+        if not os.environ.get('AMDGPU_IDS_PATH'):
+            env['AMDGPU_IDS_PATH'] = amdgpu_ids_path
+        if not os.environ.get('LIBDRM_AMDGPU_IDS_PATH'):
+            env['LIBDRM_AMDGPU_IDS_PATH'] = amdgpu_ids_path
+
     # Detect AMD GPU
     gpu_info = detect_amd_gpu()
 
@@ -153,15 +170,6 @@ def get_rocm_environment() -> Dict[str, str]:
         # Set to empty to disable file lookup that causes errors
         if not os.environ.get('AMD_TEE_LOG_PATH'):
             env['AMD_TEE_LOG_PATH'] = '/dev/null'
-
-        if not os.environ.get('AMDGPU_IDS_PATH'):
-            for candidate in (
-                '/opt/amdgpu/share/libdrm/amdgpu.ids',
-                '/usr/share/libdrm/amdgpu.ids',
-            ):
-                if os.path.isfile(candidate):
-                    env['AMDGPU_IDS_PATH'] = candidate
-                    break
 
     return env
 


### PR DESCRIPTION
### Motivation
- Prevent noisy libdrm/ROCm warnings by ensuring `AMDGPU_IDS_PATH` and `LIBDRM_AMDGPU_IDS_PATH` point to a valid `amdgpu.ids` file or to `/dev/null` so processes don't emit missing-file errors. 
- Ensure subprocess environments receive the same AMDGPU ids fallbacks even when GPU detection hasn't run or fails. 

### Description
- In `run.sh` moved and added logic to always resolve a candidate `amdgpu.ids` file (searching `/opt/amdgpu/share/libdrm/amdgpu.ids` and `/usr/share/libdrm/amdgpu.ids`) and export `AMDGPU_IDS_PATH` and `LIBDRM_AMDGPU_IDS_PATH`, falling back to `/dev/null` when none are present. 
- Kept ROCm-specific variables (e.g. `ROCR_VISIBLE_DEVICES`, `HIP_VISIBLE_DEVICES`, `HSA_OVERRIDE_GFX_VERSION`, `AMD_TEE_LOG_PATH`) applied only when an AMD GPU is detected. 
- In `vsg_core/system/gpu_env.py` added the same AMDGPU ids resolution inside `get_rocm_environment()` so the returned env always includes `AMDGPU_IDS_PATH` and `LIBDRM_AMDGPU_IDS_PATH` when not already set in the process environment, and removed the previous duplicate/late setting. 
- `get_subprocess_environment()` continues to return a copy of `os.environ` updated with the sanitized ROCm environment to be passed to subprocesses. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696858a396b4832fb43938499ea3f003)