### PR TITLE
Repair invalid AMDGPU ids env paths

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -71,6 +71,31 @@ setup_rocm_environment() {
         fi
     fi
 
+    AMDGPU_IDS_FILE=""
+    if [ -n "$AMDGPU_IDS_PATH" ] && [ -e "$AMDGPU_IDS_PATH" ]; then
+        AMDGPU_IDS_FILE="$AMDGPU_IDS_PATH"
+    elif [ -n "$LIBDRM_AMDGPU_IDS_PATH" ] && [ -e "$LIBDRM_AMDGPU_IDS_PATH" ]; then
+        AMDGPU_IDS_FILE="$LIBDRM_AMDGPU_IDS_PATH"
+    else
+        for candidate in "/opt/amdgpu/share/libdrm/amdgpu.ids" "/usr/share/libdrm/amdgpu.ids"; do
+            if [ -e "$candidate" ]; then
+                AMDGPU_IDS_FILE="$candidate"
+                break
+            fi
+        done
+    fi
+
+    if [ -z "$AMDGPU_IDS_FILE" ]; then
+        AMDGPU_IDS_FILE="/dev/null"
+    fi
+
+    if [ -z "$AMDGPU_IDS_PATH" ] || [ ! -e "$AMDGPU_IDS_PATH" ]; then
+        export AMDGPU_IDS_PATH="$AMDGPU_IDS_FILE"
+    fi
+    if [ -z "$LIBDRM_AMDGPU_IDS_PATH" ] || [ ! -e "$LIBDRM_AMDGPU_IDS_PATH" ]; then
+        export LIBDRM_AMDGPU_IDS_PATH="$AMDGPU_IDS_FILE"
+    fi
+
     # Set ROCm environment variables if AMD GPU detected
     if [ "$AMD_GPU_DETECTED" = true ]; then
         [ -z "$ROCR_VISIBLE_DEVICES" ] && export ROCR_VISIBLE_DEVICES=0

--- a/vsg_core/system/gpu_env.py
+++ b/vsg_core/system/gpu_env.py
@@ -113,6 +113,29 @@ def get_rocm_environment() -> Dict[str, str]:
     """
     env = {}
 
+    amdgpu_ids_path = None
+    existing_ids_path = os.environ.get('AMDGPU_IDS_PATH')
+    existing_libdrm_path = os.environ.get('LIBDRM_AMDGPU_IDS_PATH')
+    if existing_ids_path and os.path.exists(existing_ids_path):
+        amdgpu_ids_path = existing_ids_path
+    elif existing_libdrm_path and os.path.exists(existing_libdrm_path):
+        amdgpu_ids_path = existing_libdrm_path
+    else:
+        for candidate in (
+            '/opt/amdgpu/share/libdrm/amdgpu.ids',
+            '/usr/share/libdrm/amdgpu.ids',
+        ):
+            if os.path.exists(candidate):
+                amdgpu_ids_path = candidate
+                break
+        if not amdgpu_ids_path:
+            amdgpu_ids_path = '/dev/null'
+
+    if not existing_ids_path or not os.path.exists(existing_ids_path):
+        env['AMDGPU_IDS_PATH'] = amdgpu_ids_path
+    if not existing_libdrm_path or not os.path.exists(existing_libdrm_path):
+        env['LIBDRM_AMDGPU_IDS_PATH'] = amdgpu_ids_path
+
     # Detect AMD GPU
     gpu_info = detect_amd_gpu()
 
@@ -153,15 +176,6 @@ def get_rocm_environment() -> Dict[str, str]:
         # Set to empty to disable file lookup that causes errors
         if not os.environ.get('AMD_TEE_LOG_PATH'):
             env['AMD_TEE_LOG_PATH'] = '/dev/null'
-
-        if not os.environ.get('AMDGPU_IDS_PATH'):
-            for candidate in (
-                '/opt/amdgpu/share/libdrm/amdgpu.ids',
-                '/usr/share/libdrm/amdgpu.ids',
-            ):
-                if os.path.isfile(candidate):
-                    env['AMDGPU_IDS_PATH'] = candidate
-                    break
 
     return env
 


### PR DESCRIPTION
### Motivation
- Avoid noisy libdrm/ROCm warnings by ensuring `AMDGPU_IDS_PATH` and `LIBDRM_AMDGPU_IDS_PATH` point to a valid `amdgpu.ids` file or to `/dev/null` so consumers don't emit missing-file errors. 
- Honor existing environment values when they point to an actual file, but detect and replace invalid paths that would still trigger warnings. 
- Ensure subprocesses receive the same corrected AMDGPU ids fallback even when GPU detection hasn't run or an environment contains stale paths. 

### Description
- Updated `run.sh` to resolve an `AMDGPU_IDS_FILE` by preferring an existing valid `AMDGPU_IDS_PATH` or `LIBDRM_AMDGPU_IDS_PATH`, then searching `/opt/amdgpu/share/libdrm/amdgpu.ids` and `/usr/share/libdrm/amdgpu.ids`, and finally falling back to `/dev/null`, and export `AMDGPU_IDS_PATH`/`LIBDRM_AMDGPU_IDS_PATH` only when missing or pointing to non-existent files. 
- Updated `vsg_core/system/gpu_env.py` `get_rocm_environment()` to implement the same resolution using `os.path.exists` and to include `AMDGPU_IDS_PATH` and `LIBDRM_AMDGPU_IDS_PATH` in the returned env dict when the process env values are absent or invalid. 
- Removed the previous duplicate/late setting of `AMDGPU_IDS_PATH` in the Python helper and kept existing ROCm variable behavior unchanged. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696858a396b4832fb43938499ea3f003)