### PR TITLE
Rebase and align ROCm/AMDGPU env handling onto main

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -71,19 +71,29 @@ setup_rocm_environment() {
         fi
     fi
 
-    if [ -z "$AMDGPU_IDS_PATH" ] || [ -z "$LIBDRM_AMDGPU_IDS_PATH" ]; then
-        AMDGPU_IDS_FILE=""
+    AMDGPU_IDS_FILE=""
+    if [ -n "$AMDGPU_IDS_PATH" ] && [ -e "$AMDGPU_IDS_PATH" ]; then
+        AMDGPU_IDS_FILE="$AMDGPU_IDS_PATH"
+    elif [ -n "$LIBDRM_AMDGPU_IDS_PATH" ] && [ -e "$LIBDRM_AMDGPU_IDS_PATH" ]; then
+        AMDGPU_IDS_FILE="$LIBDRM_AMDGPU_IDS_PATH"
+    else
         for candidate in "/opt/amdgpu/share/libdrm/amdgpu.ids" "/usr/share/libdrm/amdgpu.ids"; do
-            if [ -f "$candidate" ]; then
+            if [ -e "$candidate" ]; then
                 AMDGPU_IDS_FILE="$candidate"
                 break
             fi
         done
-        if [ -z "$AMDGPU_IDS_FILE" ]; then
-            AMDGPU_IDS_FILE="/dev/null"
-        fi
-        [ -z "$AMDGPU_IDS_PATH" ] && export AMDGPU_IDS_PATH="$AMDGPU_IDS_FILE"
-        [ -z "$LIBDRM_AMDGPU_IDS_PATH" ] && export LIBDRM_AMDGPU_IDS_PATH="$AMDGPU_IDS_FILE"
+    fi
+
+    if [ -z "$AMDGPU_IDS_FILE" ]; then
+        AMDGPU_IDS_FILE="/dev/null"
+    fi
+
+    if [ -z "$AMDGPU_IDS_PATH" ] || [ ! -e "$AMDGPU_IDS_PATH" ]; then
+        export AMDGPU_IDS_PATH="$AMDGPU_IDS_FILE"
+    fi
+    if [ -z "$LIBDRM_AMDGPU_IDS_PATH" ] || [ ! -e "$LIBDRM_AMDGPU_IDS_PATH" ]; then
+        export LIBDRM_AMDGPU_IDS_PATH="$AMDGPU_IDS_FILE"
     fi
 
     # Set ROCm environment variables if AMD GPU detected

--- a/vsg_core/system/gpu_env.py
+++ b/vsg_core/system/gpu_env.py
@@ -113,22 +113,28 @@ def get_rocm_environment() -> Dict[str, str]:
     """
     env = {}
 
-    if not os.environ.get('AMDGPU_IDS_PATH') or not os.environ.get('LIBDRM_AMDGPU_IDS_PATH'):
-        amdgpu_ids_path = None
+    amdgpu_ids_path = None
+    existing_ids_path = os.environ.get('AMDGPU_IDS_PATH')
+    existing_libdrm_path = os.environ.get('LIBDRM_AMDGPU_IDS_PATH')
+    if existing_ids_path and os.path.exists(existing_ids_path):
+        amdgpu_ids_path = existing_ids_path
+    elif existing_libdrm_path and os.path.exists(existing_libdrm_path):
+        amdgpu_ids_path = existing_libdrm_path
+    else:
         for candidate in (
             '/opt/amdgpu/share/libdrm/amdgpu.ids',
             '/usr/share/libdrm/amdgpu.ids',
         ):
-            if os.path.isfile(candidate):
+            if os.path.exists(candidate):
                 amdgpu_ids_path = candidate
                 break
         if not amdgpu_ids_path:
             amdgpu_ids_path = '/dev/null'
 
-        if not os.environ.get('AMDGPU_IDS_PATH'):
-            env['AMDGPU_IDS_PATH'] = amdgpu_ids_path
-        if not os.environ.get('LIBDRM_AMDGPU_IDS_PATH'):
-            env['LIBDRM_AMDGPU_IDS_PATH'] = amdgpu_ids_path
+    if not existing_ids_path or not os.path.exists(existing_ids_path):
+        env['AMDGPU_IDS_PATH'] = amdgpu_ids_path
+    if not existing_libdrm_path or not os.path.exists(existing_libdrm_path):
+        env['LIBDRM_AMDGPU_IDS_PATH'] = amdgpu_ids_path
 
     # Detect AMD GPU
     gpu_info = detect_amd_gpu()


### PR DESCRIPTION
### Motivation
- Rebase the branch onto `origin/main` and resolve merge conflicts to allow a clean merge into `main`. 
- Make GPU/ROCm environment handling more robust by ensuring `AMDGPU` ids paths are discovered reliably and existing user settings are preserved.

### Description
- Resolved rebase conflicts and updated the launcher script `run.sh` to check `AMDGPU_IDS_PATH` and `LIBDRM_AMDGPU_IDS_PATH` before probing common locations, use `-e` for existence checks, fall back to `/dev/null`, and only export the variables when they are unset or point to missing paths. 
- Updated `vsg_core/system/gpu_env.py` to mirror the shell logic by checking existing environment variables with `os.path.exists`, searching fallback candidate paths, using `/dev/null` when none found, and only adding `AMDGPU_IDS_PATH`/`LIBDRM_AMDGPU_IDS_PATH` to the returned env when appropriate. 
- Kept the ROCm variable exports (e.g. `ROCR_VISIBLE_DEVICES`, `HIP_VISIBLE_DEVICES`, `HSA_OVERRIDE_GFX_VERSION`, `AMD_VARIANT_PROVIDER_FORCE_GFX_ARCH`, `AMD_VARIANT_PROVIDER_FORCE_ROCM_VERSION`, `AMD_TEE_LOG_PATH`) unchanged in intent but ensured they are set only when not already defined.

### Testing
- No automated tests were run; the branch was successfully rebased onto `origin/main` and conflicts in `run.sh` and `vsg_core/system/gpu_env.py` were resolved and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696860bf56cc832fa7f55631abf232af)