### PR TITLE
Always set AMDGPU ids paths for launcher and ROCm subprocesses

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -71,20 +71,26 @@ setup_rocm_environment() {
         fi
     fi
 
-    if [ -z "$AMDGPU_IDS_PATH" ] || [ -z "$LIBDRM_AMDGPU_IDS_PATH" ]; then
-        AMDGPU_IDS_FILE=""
+    AMDGPU_IDS_FILE=""
+    if [ -n "$AMDGPU_IDS_PATH" ] && [ -e "$AMDGPU_IDS_PATH" ]; then
+        AMDGPU_IDS_FILE="$AMDGPU_IDS_PATH"
+    elif [ -n "$LIBDRM_AMDGPU_IDS_PATH" ] && [ -e "$LIBDRM_AMDGPU_IDS_PATH" ]; then
+        AMDGPU_IDS_FILE="$LIBDRM_AMDGPU_IDS_PATH"
+    else
         for candidate in "/opt/amdgpu/share/libdrm/amdgpu.ids" "/usr/share/libdrm/amdgpu.ids"; do
-            if [ -f "$candidate" ]; then
+            if [ -e "$candidate" ]; then
                 AMDGPU_IDS_FILE="$candidate"
                 break
             fi
         done
-        if [ -z "$AMDGPU_IDS_FILE" ]; then
-            AMDGPU_IDS_FILE="/dev/null"
-        fi
-        [ -z "$AMDGPU_IDS_PATH" ] && export AMDGPU_IDS_PATH="$AMDGPU_IDS_FILE"
-        [ -z "$LIBDRM_AMDGPU_IDS_PATH" ] && export LIBDRM_AMDGPU_IDS_PATH="$AMDGPU_IDS_FILE"
     fi
+
+    if [ -z "$AMDGPU_IDS_FILE" ]; then
+        AMDGPU_IDS_FILE="/dev/null"
+    fi
+
+    export AMDGPU_IDS_PATH="$AMDGPU_IDS_FILE"
+    export LIBDRM_AMDGPU_IDS_PATH="$AMDGPU_IDS_FILE"
 
     # Set ROCm environment variables if AMD GPU detected
     if [ "$AMD_GPU_DETECTED" = true ]; then

--- a/vsg_core/system/gpu_env.py
+++ b/vsg_core/system/gpu_env.py
@@ -113,22 +113,26 @@ def get_rocm_environment() -> Dict[str, str]:
     """
     env = {}
 
-    if not os.environ.get('AMDGPU_IDS_PATH') or not os.environ.get('LIBDRM_AMDGPU_IDS_PATH'):
-        amdgpu_ids_path = None
+    amdgpu_ids_path = None
+    existing_ids_path = os.environ.get('AMDGPU_IDS_PATH')
+    existing_libdrm_path = os.environ.get('LIBDRM_AMDGPU_IDS_PATH')
+    if existing_ids_path and os.path.exists(existing_ids_path):
+        amdgpu_ids_path = existing_ids_path
+    elif existing_libdrm_path and os.path.exists(existing_libdrm_path):
+        amdgpu_ids_path = existing_libdrm_path
+    else:
         for candidate in (
             '/opt/amdgpu/share/libdrm/amdgpu.ids',
             '/usr/share/libdrm/amdgpu.ids',
         ):
-            if os.path.isfile(candidate):
+            if os.path.exists(candidate):
                 amdgpu_ids_path = candidate
                 break
         if not amdgpu_ids_path:
             amdgpu_ids_path = '/dev/null'
 
-        if not os.environ.get('AMDGPU_IDS_PATH'):
-            env['AMDGPU_IDS_PATH'] = amdgpu_ids_path
-        if not os.environ.get('LIBDRM_AMDGPU_IDS_PATH'):
-            env['LIBDRM_AMDGPU_IDS_PATH'] = amdgpu_ids_path
+    env['AMDGPU_IDS_PATH'] = amdgpu_ids_path
+    env['LIBDRM_AMDGPU_IDS_PATH'] = amdgpu_ids_path
 
     # Detect AMD GPU
     gpu_info = detect_amd_gpu()


### PR DESCRIPTION
### Motivation
- Stop libdrm/ROCm from falling back to missing default `amdgpu.ids` paths by ensuring a resolved path (or `/dev/null`) is always provided to the environment.
- Make the Python subprocess environment mirror the launcher behavior so GPU-enabled subprocesses see the same resolved `AMDGPU_IDS_PATH`/`LIBDRM_AMDGPU_IDS_PATH` values.

### Description
- Unconditionally export the resolved `AMDGPU_IDS_PATH` and `LIBDRM_AMDGPU_IDS_PATH` in `run.sh` after selecting an existing user-provided path, checking common candidate locations, or falling back to `/dev/null`.
- Always include `AMDGPU_IDS_PATH` and `LIBDRM_AMDGPU_IDS_PATH` in the dict returned by `get_rocm_environment()` in `vsg_core/system/gpu_env.py` after preferring any existing valid environment paths and probing the same candidate locations, with `/dev/null` as final fallback.
- Use existence checks (`-e` in shell and `os.path.exists` in Python) when probing candidate paths.
- Preserve the existing logic that sets other ROCm variables (e.g. `ROCR_VISIBLE_DEVICES`, `HIP_VISIBLE_DEVICES`, `HSA_OVERRIDE_GFX_VERSION`, `AMD_VARIANT_PROVIDER_FORCE_*`, `AMD_TEE_LOG_PATH`) only when they are not already defined.

### Testing
- No automated tests were run for this change (environment-only updates).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696860bf56cc832fa7f55631abf232af)