### PR TITLE
Integrate python-audio-separator for source separation; add model selection and fix subtitle encoding fallback

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -80,14 +80,14 @@ source Dependencies/.venv/bin/activate
 uv pip install <package-name>
 ```
 
-## Optional AI Audio Separation (Demucs)
+## Optional AI Audio Separation (Audio Separator)
 
 The base installation includes everything needed for the app. However, if you want AI-powered audio separation for cross-language sync, install one of these:
 
 ### For NVIDIA GPUs (CUDA):
 ```bash
 source Dependencies/.venv/bin/activate
-uv pip install torch demucs
+uv pip install "audio-separator[gpu]"
 ```
 
 ### For AMD GPUs (ROCm):
@@ -95,18 +95,18 @@ uv pip install torch demucs
 source Dependencies/.venv/bin/activate
 # Install PyTorch with ROCm support first
 pip install torch --index-url https://download.pytorch.org/whl/rocm6.2
-# Then install demucs
-uv pip install demucs
+# Then install audio-separator (CPU extra works with ROCm torch)
+uv pip install "audio-separator[cpu]"
 ```
 
 ### For CPU only (slower):
 ```bash
 source Dependencies/.venv/bin/activate
-# Install CPU-only PyTorch
-uv pip install torch demucs --index-url https://download.pytorch.org/whl/cpu
+# Install audio-separator CPU build
+uv pip install "audio-separator[cpu]"
 ```
 
-**Note:** Torch + Demucs is a LARGE download (several GB). Only install if you need cross-language audio separation.
+**Note:** Audio-separator downloads model files automatically on first use. Only install if you need cross-language audio separation.
 
 ## Troubleshooting
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,5 +43,5 @@ scenedetect[opencv]
 webrtcvad-wheels
 
 # Optional AI audio features - install separately if needed:
-# For AI features (torch + demucs), install with:
-#   pip install torch demucs
+# For AI features (audio-separator), install with:
+#   pip install "audio-separator[gpu]"

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -221,7 +221,7 @@ install_optional() {
         return 1
     fi
 
-    echo "Optional AI audio features (PyTorch + Demucs):"
+    echo "Optional AI audio features (Audio Separator):"
     echo "These enable AI-powered vocal/instrument separation"
     echo "for better cross-language audio correlation."
     echo ""
@@ -239,30 +239,28 @@ install_optional() {
     case $hw_choice in
         1)
             echo ""
-            echo -e "${BLUE}Installing PyTorch (NVIDIA CUDA) + Demucs...${NC}"
-            pip install torch torchvision torchaudio
-            pip install demucs
+            echo -e "${BLUE}Installing Audio Separator (NVIDIA CUDA)...${NC}"
+            pip install "audio-separator[gpu]"
             echo -e "${GREEN}✓ NVIDIA GPU support installed${NC}"
             ;;
         2)
             echo ""
-            echo -e "${BLUE}Installing PyTorch (AMD ROCm 6.4 Stable) + Demucs...${NC}"
+            echo -e "${BLUE}Installing Audio Separator (AMD ROCm 6.4 Stable)...${NC}"
             pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm6.4
-            pip install demucs
+            pip install "audio-separator[cpu]"
             echo -e "${GREEN}✓ AMD GPU (ROCm 6.4) support installed${NC}"
             ;;
         3)
             echo ""
-            echo -e "${BLUE}Installing PyTorch (AMD ROCm 7.1 Nightly) + Demucs...${NC}"
+            echo -e "${BLUE}Installing Audio Separator (AMD ROCm 7.1 Nightly)...${NC}"
             pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.1
-            pip install demucs
+            pip install "audio-separator[cpu]"
             echo -e "${GREEN}✓ AMD GPU (ROCm 7.1) support installed${NC}"
             ;;
         4)
             echo ""
-            echo -e "${BLUE}Installing PyTorch (CPU only) + Demucs...${NC}"
-            pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
-            pip install demucs
+            echo -e "${BLUE}Installing Audio Separator (CPU only)...${NC}"
+            pip install "audio-separator[cpu]"
             echo -e "${GREEN}✓ CPU-only support installed${NC}"
             ;;
         5)
@@ -342,12 +340,10 @@ verify_dependencies() {
     # Check optional dependencies
     echo ""
     echo -e "${YELLOW}Checking optional AI audio dependencies...${NC}"
-    if pip show torch &> /dev/null && pip show demucs &> /dev/null; then
-        torch_version=$(pip show torch 2>/dev/null | grep "^Version:" | cut -d' ' -f2)
-        demucs_version=$(pip show demucs 2>/dev/null | grep "^Version:" | cut -d' ' -f2)
+    if pip show audio-separator &> /dev/null; then
+        sep_version=$(pip show audio-separator 2>/dev/null | grep "^Version:" | cut -d' ' -f2)
         echo -e "${GREEN}✓ AI audio features installed${NC}"
-        echo "  torch ($torch_version)"
-        echo "  demucs ($demucs_version)"
+        echo "  audio-separator ($sep_version)"
     else
         echo -e "${YELLOW}○ AI audio features not installed (optional)${NC}"
         echo "  Use option 3 to install them"

--- a/vsg_core/analysis/__init__.py
+++ b/vsg_core/analysis/__init__.py
@@ -3,12 +3,17 @@
 from .audio_corr import run_audio_correlation
 from .videodiff import run_videodiff
 from .drift_detection import diagnose_audio_issue
-from .source_separation import is_demucs_available, SEPARATION_MODES
+from .source_separation import (
+    is_audio_separator_available,
+    list_available_models,
+    SEPARATION_MODES,
+)
 
 __all__ = [
     "run_audio_correlation",
     "run_videodiff",
     "diagnose_audio_issue",
-    "is_demucs_available",
+    "is_audio_separator_available",
+    "list_available_models",
     "SEPARATION_MODES",
 ]

--- a/vsg_core/analysis/audio_corr.py
+++ b/vsg_core/analysis/audio_corr.py
@@ -433,8 +433,8 @@ def run_audio_correlation(
     tgt_pcm = _decode_to_memory(target_file, idx_tgt, DEFAULT_SR, use_soxr, runner, tool_paths)
 
     # --- 2b. Source Separation (Optional) ---
-    separation_model = config.get('source_separation_model', 'None (Use Original Audio)')
-    if separation_model and separation_model != 'None (Use Original Audio)':
+    separation_mode = config.get('source_separation_mode', 'none')
+    if separation_mode and separation_mode != 'none':
         try:
             from .source_separation import apply_source_separation
             ref_pcm, tgt_pcm = apply_source_separation(
@@ -646,8 +646,8 @@ def run_multi_correlation(
     tgt_pcm = _decode_to_memory(target_file, idx_tgt, DEFAULT_SR, use_soxr, runner, tool_paths)
 
     # --- 2b. Source Separation (Optional) ---
-    separation_model = config.get('source_separation_model', 'None (Use Original Audio)')
-    if separation_model and separation_model != 'None (Use Original Audio)':
+    separation_mode = config.get('source_separation_mode', 'none')
+    if separation_mode and separation_mode != 'none':
         try:
             from .source_separation import apply_source_separation
             ref_pcm, tgt_pcm = apply_source_separation(

--- a/vsg_core/analysis/source_separation.py
+++ b/vsg_core/analysis/source_separation.py
@@ -1,28 +1,28 @@
 # vsg_core/analysis/source_separation.py
 # -*- coding: utf-8 -*-
 """
-Audio source separation using Demucs for cross-language correlation.
+Audio source separation using python-audio-separator for cross-language correlation.
 
-This module runs Demucs in a subprocess to ensure complete memory cleanup
+This module runs separation in a subprocess to ensure complete memory cleanup
 after processing. When the subprocess exits, all GPU/CPU memory is freed
-by the OS - solving the common PyTorch memory leak issue.
-
-Use case: When correlating Japanese and English audio, the vocal tracks
-differ completely. By separating and removing vocals, we can correlate
-on music/effects which should be identical between releases.
+by the OS - solving common PyTorch/ONNX memory leak issues.
 """
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import Callable, Dict, Optional, Tuple
+from typing import Callable, Dict, Optional, Tuple, List
 
 import numpy as np
+from scipy.io import wavfile
+from scipy.signal import resample_poly
+from math import gcd
 
 # Import GPU environment support
 try:
@@ -31,15 +31,18 @@ except ImportError:
     def get_subprocess_environment():
         return os.environ.copy()
 
+
 # Separation modes available in the UI
 SEPARATION_MODES = {
-    'None (Use Original Audio)': None,
-    'Demucs - Music/Effects (Strip Vocals)': 'no_vocals',
-    'Demucs - Vocals Only': 'vocals_only',
+    'none': None,
+    'instrumental': 'Instrumental',
+    'vocals': 'Vocals',
 }
 
+DEFAULT_MODEL = 'default'
 
-def _get_venv_python():
+
+def _get_venv_python() -> str:
     """
     Get the correct Python executable from the current virtual environment.
 
@@ -48,204 +51,159 @@ def _get_venv_python():
 
     As a backup, we also check for a .venv directory in the project root.
     """
-    # First priority: if we're running from a venv, sys.executable is correct
-    # Check if we're in a virtual environment
     if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
-        # We're in a venv - sys.executable should point to it
         return sys.executable
 
-    # Backup: Look for .venv in the project directory
-    # (In case the app was launched without properly activating the venv)
     project_root = Path(__file__).resolve().parent.parent.parent
     venv_python = project_root / '.venv' / 'bin' / 'python'
     if venv_python.is_file():
         return str(venv_python)
 
-    # Last resort: use whatever Python we're running with
     return sys.executable
 
 
-def is_demucs_available() -> Tuple[bool, str]:
+def is_audio_separator_available() -> Tuple[bool, str]:
     """
-    Check if Demucs and its dependencies are available.
+    Check if python-audio-separator is available.
 
     Returns:
         Tuple of (available: bool, message: str)
     """
+    if importlib.util.find_spec('audio_separator') is None:
+        return False, "audio-separator not installed. Install with: pip install \"audio-separator[gpu]\""
+
+    return True, "audio-separator available"
+
+
+def list_available_models() -> List[Tuple[str, str]]:
+    """
+    Get available model filenames from audio-separator's bundled model list.
+
+    Returns:
+        List of (friendly_name, filename) tuples.
+    """
     try:
-        import torch
-        torch_version = torch.__version__
+        import importlib.resources as resources
 
-        # Check for GPU support (works for both CUDA and ROCm)
-        if torch.cuda.is_available():
-            device_name = torch.cuda.get_device_name(0)
-            # Check if this is ROCm (HIP) or CUDA
-            hip_version = getattr(torch.version, 'hip', None)
-            if hip_version:
-                gpu_info = f"ROCm GPU: {device_name}"
-            else:
-                gpu_info = f"CUDA GPU: {device_name}"
-        else:
-            gpu_info = "CPU only (no CUDA/ROCm detected)"
+        with resources.open_text('audio_separator', 'models.json') as f:
+            model_data = json.load(f)
+    except Exception:
+        return []
 
-    except ImportError:
-        return False, "PyTorch not installed. Install with: pip install torch"
+    models: Dict[str, str] = {}
+    for group in model_data.values():
+        if isinstance(group, dict):
+            models.update(group)
 
-    try:
-        import demucs
-        demucs_version = getattr(demucs, '__version__', 'unknown')
-    except ImportError:
-        return False, f"Demucs not installed (torch {torch_version} found). Install with: pip install demucs"
-
-    return True, f"Demucs {demucs_version}, torch {torch_version}, {gpu_info}"
+    return sorted(models.items(), key=lambda item: item[0].lower())
 
 
-# --- Subprocess Worker Script ---
-# This script runs in a separate process to ensure memory cleanup
-
-_WORKER_SCRIPT = '''
-import sys
-import json
-import numpy as np
-from scipy.signal import resample_poly
-from math import gcd
-
-def resample_audio(audio_np, orig_sr, target_sr):
+def resample_audio(audio_np: np.ndarray, orig_sr: int, target_sr: int) -> np.ndarray:
     """Resample audio using scipy (no torchaudio needed)."""
     if orig_sr == target_sr:
         return audio_np
-    # Use rational resampling for better quality
     g = gcd(orig_sr, target_sr)
     up = target_sr // g
     down = orig_sr // g
     return resample_poly(audio_np, up, down).astype(np.float32)
 
-def run_separation(input_path, output_path, mode, sample_rate, device_preference):
-    """Run Demucs separation in isolated process."""
-    import torch
-    from demucs.pretrained import get_model
-    from demucs.apply import apply_model
 
-    # Load audio from temp file
-    audio = np.load(input_path)
+_WORKER_SCRIPT = '''
+import json
+import sys
+from audio_separator.separator import Separator
 
-    # Determine device
-    if device_preference == 'cpu':
-        device = torch.device('cpu')
-    elif device_preference == 'mps':
-        if hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
-            device = torch.device('mps')
-        else:
-            device = torch.device('cpu')
-    elif device_preference in ('cuda', 'rocm'):
-        if torch.cuda.is_available():
-            device = torch.device('cuda')
-        else:
-            device = torch.device('cpu')
-    elif torch.cuda.is_available():
-        device = torch.device('cuda')
-    elif hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
-        device = torch.device('mps')
+def run_separation(args):
+    separator = Separator(
+        output_dir=args['output_dir'],
+        output_format='WAV',
+        output_single_stem=args['target_stem'],
+        sample_rate=args['sample_rate'],
+    )
+
+    model_filename = args.get('model_filename')
+    if model_filename and model_filename != 'default':
+        separator.load_model(model_filename=model_filename)
     else:
-        device = torch.device('cpu')
+        separator.load_model()
 
-    device_label = device.type
-    hip_version = getattr(torch.version, 'hip', None)
-    if device.type == 'cuda' and hip_version:
-        device_label = f"rocm ({hip_version})"
-    print(f"Using device: {device_label}", file=sys.stderr)
+    output_files = separator.separate(args['input_path'])
+    if not output_files:
+        raise RuntimeError('No output files produced by audio-separator')
 
-    # Load model (htdemucs is good balance of quality/speed)
-    model = get_model('htdemucs')
-    model.to(device)
-    model.eval()
-
-    # Resample to 44100 Hz if needed (Demucs expects 44100 Hz)
-    if sample_rate != 44100:
-        audio = resample_audio(audio, sample_rate, 44100)
-
-    # Prepare audio tensor: (batch, channels, samples)
-    # Input is mono float32, convert to stereo for Demucs
-    audio_tensor = torch.from_numpy(audio).float()
-    if audio_tensor.dim() == 1:
-        audio_tensor = audio_tensor.unsqueeze(0).repeat(2, 1)  # mono -> stereo
-    audio_tensor = audio_tensor.unsqueeze(0)  # add batch dim
-    audio_tensor = audio_tensor.to(device)
-
-    # Apply model
-    with torch.no_grad():
-        sources = apply_model(model, audio_tensor, device=device)
-
-    # sources shape: (batch, num_sources, channels, samples)
-    # htdemucs sources: drums, bass, other, vocals (indices 0,1,2,3)
-    sources = sources.squeeze(0)  # remove batch dim
-
-    if mode == 'no_vocals':
-        # Combine drums + bass + other (exclude vocals at index 3)
-        result = sources[0] + sources[1] + sources[2]
-    elif mode == 'vocals_only':
-        result = sources[3]
-    else:
-        # Fallback: return original
-        result = sources.sum(dim=0)
-
-    # Convert back to mono
-    result = result.mean(dim=0)  # stereo -> mono
-
-    # Move to CPU and convert to numpy
-    result_np = result.cpu().numpy().astype(np.float32)
-
-    # Resample back to original sample rate if needed
-    if sample_rate != 44100:
-        result_np = resample_audio(result_np, 44100, sample_rate)
-
-    # Save result
-    np.save(output_path, result_np)
-
-    # Explicit cleanup
-    del model, sources, audio_tensor, result
-    if torch.cuda.is_available():
-        torch.cuda.empty_cache()
-
-    return True
+    return output_files[0]
 
 if __name__ == '__main__':
     args = json.loads(sys.argv[1])
     try:
-        run_separation(
-            args['input_path'],
-            args['output_path'],
-            args['mode'],
-            args['sample_rate'],
-            args['device']
-        )
-        print(json.dumps({'success': True}))
+        output_path = run_separation(args)
+        print(json.dumps({'success': True, 'output_path': output_path}))
     except Exception as e:
         print(json.dumps({'success': False, 'error': str(e)}))
         sys.exit(1)
 '''
 
 
+def _read_audio_file(path: Path) -> Tuple[int, np.ndarray]:
+    """Read audio file and return (sample_rate, mono float32 array)."""
+    sample_rate, data = wavfile.read(path)
+
+    if data.dtype.kind in 'iu':
+        max_val = np.iinfo(data.dtype).max
+        data = data.astype(np.float32) / max_val
+    else:
+        data = data.astype(np.float32)
+
+    if data.ndim > 1:
+        data = data.mean(axis=1)
+
+    return sample_rate, data
+
+
+def _resolve_separation_settings(config: Dict) -> Tuple[str, str]:
+    mode = config.get('source_separation_mode')
+    model_filename = config.get('source_separation_model', DEFAULT_MODEL)
+
+    if mode is None:
+        legacy_value = config.get('source_separation_model', '')
+        legacy_map = {
+            'Demucs - Music/Effects (Strip Vocals)': 'instrumental',
+            'Demucs - Vocals Only': 'vocals',
+        }
+        if legacy_value in legacy_map:
+            mode = legacy_map[legacy_value]
+            model_filename = DEFAULT_MODEL
+
+    if mode not in SEPARATION_MODES:
+        mode = 'none'
+
+    return mode, model_filename
+
+
+def is_separation_enabled(config: Dict) -> bool:
+    mode, _ = _resolve_separation_settings(config)
+    return SEPARATION_MODES.get(mode) is not None
+
+
 def separate_audio(
     pcm_data: np.ndarray,
     sample_rate: int,
     mode: str,
+    model_filename: str,
     log_func: Optional[Callable[[str], None]] = None,
     device: str = 'auto',
     timeout_seconds: int = 300
 ) -> Optional[np.ndarray]:
     """
-    Separate audio using Demucs in an isolated subprocess.
-
-    This function spawns a separate Python process to run Demucs,
-    ensuring complete memory cleanup when separation is done.
+    Separate audio using python-audio-separator in an isolated subprocess.
 
     Args:
         pcm_data: Input audio as float32 numpy array
         sample_rate: Sample rate of the audio (e.g., 48000)
-        mode: Separation mode ('no_vocals' or 'vocals_only')
+        mode: Separation mode ('instrumental' or 'vocals')
+        model_filename: Model filename to use (or 'default')
         log_func: Optional logging function
-        device: 'auto', 'cuda', 'rocm', or 'cpu'
+        device: 'auto', 'cpu', 'cuda', 'rocm', or 'mps'
         timeout_seconds: Maximum time to wait for separation
 
     Returns:
@@ -253,61 +211,53 @@ def separate_audio(
     """
     log = log_func or (lambda x: None)
 
-    if mode not in ('no_vocals', 'vocals_only'):
-        log(f"[SOURCE SEPARATION] Unknown mode '{mode}', returning original audio")
+    target_stem = SEPARATION_MODES.get(mode)
+    if target_stem is None:
+        log(f"[SOURCE SEPARATION] Mode '{mode}' disabled, returning original audio")
         return pcm_data
 
-    # Check availability first
-    available, msg = is_demucs_available()
+    available, msg = is_audio_separator_available()
     if not available:
-        log(f"[SOURCE SEPARATION] Demucs not available: {msg}")
+        log(f"[SOURCE SEPARATION] Audio-separator not available: {msg}")
         return None
 
-    log(f"[SOURCE SEPARATION] Starting Demucs separation (mode={mode})...")
+    log(f"[SOURCE SEPARATION] Starting audio-separator (mode={mode}, model={model_filename})...")
     log(f"[SOURCE SEPARATION] {msg}")
 
-    # Create temp files for IPC
-    with tempfile.TemporaryDirectory(prefix='demucs_') as temp_dir:
+    with tempfile.TemporaryDirectory(prefix='audio_sep_') as temp_dir:
         temp_path = Path(temp_dir)
-        input_path = temp_path / 'input.npy'
-        output_path = temp_path / 'output.npy'
+        input_path = temp_path / 'input.wav'
         script_path = temp_path / 'worker.py'
+        output_dir = temp_path / 'output'
 
-        # Save input audio
-        np.save(input_path, pcm_data)
-
-        # Write worker script
+        wavfile.write(input_path, sample_rate, pcm_data.astype(np.float32))
         script_path.write_text(_WORKER_SCRIPT)
-
-        # Prepare arguments
-        device_preference = device
-        if device in ('cuda', 'rocm'):
-            device_preference = 'cuda'
-        elif device not in ('cpu', 'mps', 'auto'):
-            device_preference = 'auto'
 
         args = {
             'input_path': str(input_path),
-            'output_path': str(output_path),
-            'mode': mode,
+            'output_dir': str(output_dir),
+            'target_stem': target_stem,
             'sample_rate': sample_rate,
-            'device': device_preference
+            'model_filename': model_filename,
         }
 
-        # Run subprocess with venv Python and GPU environment
         python_exe = _get_venv_python()
         log(f"[SOURCE SEPARATION] Using Python: {python_exe}")
 
-        # Get environment with GPU support
         env = get_subprocess_environment()
+        if device == 'cpu':
+            env['CUDA_VISIBLE_DEVICES'] = ''
+            env['ROCR_VISIBLE_DEVICES'] = ''
+            env['HIP_VISIBLE_DEVICES'] = ''
 
         try:
+            timeout = None if timeout_seconds <= 0 else timeout_seconds
             result = subprocess.run(
                 [python_exe, str(script_path), json.dumps(args)],
                 capture_output=True,
                 text=True,
-                timeout=timeout_seconds,
-                env=env  # Pass environment with ROCm variables
+                timeout=timeout,
+                env=env,
             )
 
             if result.returncode != 0:
@@ -326,26 +276,32 @@ def separate_audio(
                 for line in result.stderr.splitlines():
                     log(f"[SOURCE SEPARATION] {line}")
 
-            # Parse result
             try:
                 response = json.loads(result.stdout.strip())
-                if not response.get('success'):
-                    log(f"[SOURCE SEPARATION] Separation failed: {response.get('error', 'unknown error')}")
-                    return None
             except json.JSONDecodeError:
-                # Some output but not JSON - might be warnings, check if output exists
-                if not output_path.exists():
-                    log(f"[SOURCE SEPARATION] No output produced. stdout: {result.stdout[:200]}")
-                    return None
-
-            # Load result
-            if output_path.exists():
-                separated = np.load(output_path)
-                log(f"[SOURCE SEPARATION] Separation complete. Output length: {len(separated)} samples")
-                return separated
-            else:
-                log("[SOURCE SEPARATION] Output file not created")
+                log(f"[SOURCE SEPARATION] Invalid JSON from worker: {result.stdout[:200]}")
                 return None
+
+            if not response.get('success'):
+                log(f"[SOURCE SEPARATION] Separation failed: {response.get('error', 'unknown error')}")
+                return None
+
+            output_path = response.get('output_path')
+            if not output_path:
+                log("[SOURCE SEPARATION] No output path provided")
+                return None
+
+            output_file = Path(output_path)
+            if not output_file.exists():
+                log(f"[SOURCE SEPARATION] Output file not found: {output_file}")
+                return None
+
+            output_sr, separated = _read_audio_file(output_file)
+            if output_sr != sample_rate:
+                separated = resample_audio(separated, output_sr, sample_rate)
+
+            log(f"[SOURCE SEPARATION] Separation complete. Output length: {len(separated)} samples")
+            return separated
 
         except subprocess.TimeoutExpired:
             log(f"[SOURCE SEPARATION] Timeout after {timeout_seconds}s")
@@ -367,41 +323,29 @@ def apply_source_separation(
 
     This is the main entry point called from audio_corr.py.
     If separation fails or is disabled, returns original audio unchanged.
-
-    Args:
-        ref_pcm: Reference audio (float32 numpy array)
-        tgt_pcm: Target audio (float32 numpy array)
-        sample_rate: Sample rate (e.g., 48000)
-        config: Configuration dictionary
-        log_func: Optional logging function
-
-    Returns:
-        Tuple of (processed_ref, processed_tgt)
     """
     log = log_func or (lambda x: None)
 
-    separation_model = config.get('source_separation_model', 'None (Use Original Audio)')
+    mode, model_filename = _resolve_separation_settings(config)
 
-    # Check if separation is enabled
-    mode = SEPARATION_MODES.get(separation_model)
-    if mode is None:
+    target_stem = SEPARATION_MODES.get(mode)
+    if target_stem is None:
         return ref_pcm, tgt_pcm
 
     device = config.get('source_separation_device', 'auto')
     timeout = config.get('source_separation_timeout', 300)
 
-    log(f"[SOURCE SEPARATION] Mode: {separation_model}")
+    log(f"[SOURCE SEPARATION] Mode: {mode}")
+    log(f"[SOURCE SEPARATION] Model: {model_filename}")
 
-    # Process reference audio
     log("[SOURCE SEPARATION] Processing reference audio...")
-    ref_separated = separate_audio(ref_pcm, sample_rate, mode, log, device, timeout)
+    ref_separated = separate_audio(ref_pcm, sample_rate, mode, model_filename, log, device, timeout)
     if ref_separated is None:
         log("[SOURCE SEPARATION] Reference separation failed, using original audio")
         return ref_pcm, tgt_pcm
 
-    # Process target audio
     log("[SOURCE SEPARATION] Processing target audio...")
-    tgt_separated = separate_audio(tgt_pcm, sample_rate, mode, log, device, timeout)
+    tgt_separated = separate_audio(tgt_pcm, sample_rate, mode, model_filename, log, device, timeout)
     if tgt_separated is None:
         log("[SOURCE SEPARATION] Target separation failed, using original audio")
         return ref_pcm, tgt_pcm


### PR DESCRIPTION
### Motivation
- Replace the older Demucs-specific separation path with a more flexible package that auto-downloads models and supports multiple architectures and runtimes (`audio-separator`).
- Surface separation controls in the UI so users can pick a separation `mode` and specific `model` for better cross-language correlation workflows.
- Make setup and installer flows recommend the new package and make optional AI dependencies easier to install for GPU/CPU users.
- Improve robustness when capturing original subtitle files by handling multiple possible encodings and falling back safely.

### Description
- Rewrote `vsg_core/analysis/source_separation.py` to run `python-audio-separator` in an isolated subprocess, added `is_audio_separator_available`, `list_available_models`, `SEPARATION_MODES`, model selection, resampling helpers, and a small worker script wrapper to return a produced output path.
- Updated correlation pipeline in `vsg_core/analysis/audio_corr.py` to use the new `source_separation_mode` + `source_separation_model` settings and call `apply_source_separation` when enabled.
- Added new config entries and validation in `vsg_core/config.py` (`source_separation_mode`, `source_separation_model`), including legacy mapping from previous Demucs-style selections.
- Exposed separation controls in the Analysis options UI (`vsg_qt/options_dialog/tabs.py`) with separate `mode` and `model` comboboxes that populate models via `list_available_models`.
- Switched installer/docs to recommend `audio-separator` (`pip install "audio-separator[gpu]"` / `"audio-separator[cpu]"`) and updated `setup_env.sh`, `SETUP.md`, and `requirements.txt` accordingly.
- Fixed subtitle metadata capture in `vsg_core/subtitles/metadata_preserver.py` to try multiple encodings (`utf-8-sig`, `utf-8`, `cp1252`, `latin1`, `shift_jis`, `gbk`) and fall back to a replacement decode to preserve `original_content` and record `self.encoding`/`self.has_bom`.
- Updated analysis package exports in `vsg_core/analysis/__init__.py` to include the new helpers (`is_audio_separator_available`, `list_available_models`).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696870468ebc832fb425576ef891e7ab)