### PR TITLE
Improve audio-separator model discovery and add configurable model directory

### DIFF
--- a/vsg_core/config.py
+++ b/vsg_core/config.py
@@ -133,6 +133,7 @@ class AppConfig:
             # --- Flexible Analysis Settings ---
             'source_separation_mode': 'none',  # 'none', 'instrumental', 'vocals'
             'source_separation_model': 'default',  # Model filename or 'default'
+            'source_separation_model_dir': str(self.script_dir / 'audio_separator_models'),
             'source_separation_device': 'auto',  # Device for source separation: 'auto', 'cpu', 'cuda', 'rocm', 'mps'
             'source_separation_timeout': 300,  # Timeout in seconds for source separation (0 = no timeout)
             'filtering_method': 'Dialogue Band-Pass Filter',

--- a/vsg_qt/options_dialog/tabs.py
+++ b/vsg_qt/options_dialog/tabs.py
@@ -156,6 +156,12 @@ class AnalysisTab(QWidget):
             "Requires: audio-separator (with GPU or CPU extras)\n"
             "Note: Runs in subprocess for guaranteed memory cleanup."
         )
+        self.widgets['source_separation_model_dir'] = _dir_input()
+        self.widgets['source_separation_model_dir'].setToolTip(
+            "Directory where audio-separator stores models.\n\n"
+            "Defaults to the application's audio_separator_models folder.\n"
+            "Models are downloaded automatically on first use."
+        )
         self.widgets['filtering_method'] = QComboBox(); self.widgets['filtering_method'].addItems(['None', 'Low-Pass Filter', 'Dialogue Band-Pass Filter']); self.widgets['filtering_method'].setToolTip("Apply a filter to the audio before analysis to improve the signal-to-noise ratio.\n'Dialogue Band-Pass' is recommended for most content.")
         self.cutoff_container = QWidget()
         cutoff_layout = QFormLayout(self.cutoff_container); cutoff_layout.setContentsMargins(0, 0, 0, 0)
@@ -163,6 +169,7 @@ class AnalysisTab(QWidget):
         cutoff_layout.addRow("Low-Pass Cutoff:", self.widgets['audio_bandlimit_hz'])
         prep_layout.addRow("Source Separation:", self.widgets['source_separation_mode'])
         prep_layout.addRow("Separation Model:", self.widgets['source_separation_model'])
+        prep_layout.addRow("Model Directory:", self.widgets['source_separation_model_dir'])
         prep_layout.addRow("Audio Filtering:", self.widgets['filtering_method'])
         prep_layout.addRow(self.cutoff_container)
         main_layout.addWidget(prep_group)


### PR DESCRIPTION
### Motivation
- Users reported the Source Separation model dropdown only showed `default` because the bundled audio-separator model list can be nested/irregular and filenames were not always being extracted correctly. 
- Provide sensible defaults (Demucs / Roformer) so the UI is usable even when parsing the bundle fails. 
- Allow configuring where models are stored so users can point the audio-separator to a persistent folder and the worker can find/download models there.

### Description
- Robust model parsing: enhanced `_collect_models_from_dict` and `_collect_models_from_list` to better detect filename entries and added helper `_select_model_filename` to pick preferred model files (checks `.ckpt`, `.onnx`, `.pth`, `.pt`, `.th`, then YAML, then any string key). (changes in `vsg_core/analysis/source_separation.py`).
- Fallback recommendations: added `_fallback_models()` to return a few recommended entries (Demucs + Roformer) when no models are discovered from the audio-separator package. (in `vsg_core/analysis/source_separation.py`).
- Model directory support: added a new config default `source_separation_model_dir` and exposed it in the Analysis UI as `Model Directory:` so users can change where audio-separator stores models. (changes in `vsg_core/config.py` and `vsg_qt/options_dialog/tabs.py`).
- Worker + runtime plumbing: extended `separate_audio` to accept `model_dir`, pass `model_dir` into the worker args, and set `Separator(..., model_file_dir=...)` in the embedded worker script so the audio-separator CLI will use the configured model directory; added a log line showing the model directory when set. (changes in `vsg_core/analysis/source_separation.py`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696888cd1d1c832f82829726115b0872)