### PR TITLE
Align curated audio-separator model filenames and add download helper

### DIFF
--- a/vsg_core/analysis/source_separation.py
+++ b/vsg_core/analysis/source_separation.py
@@ -43,6 +43,36 @@ SEPARATION_MODES = {
 
 DEFAULT_MODEL = 'default'
 
+# Curated list of best-performing models for UI selection.
+# These are intentionally limited to avoid overwhelming users with large lists.
+CURATED_MODELS: List[Dict[str, str]] = [
+    {
+        'name': 'Demucs v4: htdemucs',
+        'filename': 'htdemucs.yaml',
+        'description': 'Best all-round 4-stem separation with strong balance across vocals and instruments.',
+    },
+    {
+        'name': 'Roformer: BandSplit SDR 1053 (Viperx)',
+        'filename': 'config_bs_roformer_ep_937_sdr_10.5309.yaml',
+        'description': 'High-quality Roformer model with excellent overall stem clarity (vocals + instruments).',
+    },
+    {
+        'name': 'MDX23C: InstVoc HQ',
+        'filename': 'model_2_stem_full_band_8k.yaml',
+        'description': 'Focused 2-stem instrumental/vocals model; strong for dialogue and music split.',
+    },
+    {
+        'name': 'MDX-Net: Kim Vocal 2',
+        'filename': 'Kim_Vocal_2.onnx',
+        'description': 'Reliable vocals-only extraction for speech-heavy content.',
+    },
+    {
+        'name': 'Bandit v2: Cinematic Multilang',
+        'filename': 'config_dnr_bandit_v2_mus64.yaml',
+        'description': 'Dialogue-friendly model for noisy mixes and multilingual sources.',
+    },
+]
+
 
 def _get_venv_python() -> str:
     """
@@ -195,39 +225,19 @@ def _select_model_filename(file_map: Dict) -> Optional[str]:
 
 def list_available_models() -> List[Tuple[str, str]]:
     """
-    Get available model filenames from audio-separator's bundled model list.
+    Get curated model filenames for audio-separator.
 
     Returns:
         List of (friendly_name, filename) tuples.
     """
-    available, _ = is_audio_separator_available()
-    if not available:
-        return []
-
-    model_data = _load_model_data_via_cli()
-    if model_data is None:
-        model_data = _load_model_data()
-        if model_data is None:
-            return []
-
-    models: Dict[str, str] = {}
-    if isinstance(model_data, dict):
-        _collect_models_from_dict(model_data, models)
-    elif isinstance(model_data, list):
-        _collect_models_from_list(model_data, models)
-
-    if not models:
-        models.update(_fallback_models())
-
-    return sorted(models.items(), key=lambda item: item[0].lower())
+    return [
+        (f"{model['name']} — {model['description']}", model['filename'])
+        for model in CURATED_MODELS
+    ]
 
 
 def _fallback_models() -> Dict[str, str]:
-    return {
-        'Demucs v4: htdemucs (recommended)': 'htdemucs.yaml',
-        'Roformer: BandSplit SDR 1053 (recommended)': 'model_bs_roformer_ep_937_sdr_10.5309.ckpt',
-        'Roformer: MelBand Karaoke (vocals)': 'mel_band_roformer_karaoke_aufr33_viperx_sdr_10.1956.ckpt',
-    }
+    return {model['name']: model['filename'] for model in CURATED_MODELS}
 
 
 def resample_audio(audio_np: np.ndarray, orig_sr: int, target_sr: int) -> np.ndarray:

--- a/vsg_qt/options_dialog/tabs.py
+++ b/vsg_qt/options_dialog/tabs.py
@@ -152,7 +152,7 @@ class AnalysisTab(QWidget):
             self.widgets['source_separation_model'].addItem(f"{name} ({filename})", filename)
         self.widgets['source_separation_model'].setToolTip(
             "Select the audio-separator model to use.\n\n"
-            "Models are downloaded automatically on first use.\n"
+            "Curated models are shown here; download via setup_env.sh if needed.\n"
             "Requires: audio-separator (with GPU or CPU extras)\n"
             "Note: Runs in subprocess for guaranteed memory cleanup."
         )


### PR DESCRIPTION
### Motivation
- Ensure the curated model list matches `audio-separator` expectations by using config filenames where appropriate so models can be run reliably (vocals/instruments splits).
- Keep the UI focused by presenting a small, hand-picked set of reliable separator models instead of a large dynamic list.
- Provide an easy, reproducible way to obtain those curated models and respect a configured model directory when present in `settings.json`.

### Description
- Update `vsg_core/analysis/source_separation.py` to use config/YAML filenames and refined descriptions for several curated models and return the curated list from `list_available_models()` instead of dynamically scraping bundled data, and make `_fallback_models()` reflect the curated set.
- Add `get_audio_separator_model_dir()` and `download_audio_separator_models()` to `setup_env.sh`, embed curated model filenames and download URLs, create the model directory, and report success/fail per file.
- Expose the download helper via an interactive menu entry and a CLI flag `--download-models`, and adjust interactive menu numbering and prompts accordingly in `setup_env.sh`.
- Update the analysis UI tooltip in `vsg_qt/options_dialog/tabs.py` to indicate curated models should be downloaded via `setup_env.sh` and show model filename choices in the model selector.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69688e8ac5b4832f8814783eccbca589)