### PR TITLE
Fix audio-separator API usage - use load_model() instead of __init__ …

### DIFF
--- a/vsg_core/analysis/source_separation.py
+++ b/vsg_core/analysis/source_separation.py
@@ -767,13 +767,16 @@ import sys
 sys.path.insert(0, r"{Path(__file__).parent.parent.parent}")
 from audio_separator.separator import Separator
 
-# Initialize separator with the model - this triggers download
+# Initialize separator with config
 print("[download_model] Creating Separator instance...")
 separator = Separator(
     model_file_dir=r"{model_dir}",
-    model_filename="{model_filename}",
     output_dir=r"{model_dir}",
 )
+
+# Load the model - this triggers download if not present
+print("[download_model] Loading model {model_filename}...")
+separator.load_model(model_filename="{model_filename}")
 print("[download_model] Model downloaded successfully")
 sys.exit(0)
 '''


### PR DESCRIPTION
…parameter

The Separator class API works as follows:
1. Initialize: Separator(model_file_dir=..., output_dir=...)
2. Load model: separator.load_model(model_filename='...')

The model_filename parameter belongs to load_model(), not __init__(). This was causing TypeError: Separator.__init__() got an unexpected keyword argument 'model_filename'

Now the download script correctly:
- Creates Separator instance with directories
- Calls load_model(model_filename=...) to trigger download