### PR TITLE
Update default source_separation_timeout in config from 300s to 900s

### DIFF
--- a/vsg_core/config.py
+++ b/vsg_core/config.py
@@ -135,7 +135,7 @@ class AppConfig:
             'source_separation_model': 'default',  # Model filename or 'default'
             'source_separation_model_dir': str(self.script_dir / 'audio_separator_models'),
             'source_separation_device': 'auto',  # Device for source separation: 'auto', 'cpu', 'cuda', 'rocm', 'mps'
-            'source_separation_timeout': 300,  # Timeout in seconds for source separation (0 = no timeout)
+            'source_separation_timeout': 900,  # Timeout in seconds for source separation (0 = no timeout, default 900s = 15 min)
             'filtering_method': 'Dialogue Band-Pass Filter',
             'correlation_method': 'Phase Correlation (GCC-PHAT)',
             'min_accepted_chunks': 3,


### PR DESCRIPTION
The previous commit updated the function defaults to 900s, but the default config dictionary in config.py still had the old 300s value.

This config default takes precedence and was causing the timeout to still be 300s even with the updated code.

Now both defaults are consistent at 900s (15 minutes).