### PR TITLE
Fix 'Signal source has been deleted' cascade crashes

### DIFF
--- a/vsg_core/analysis/audio_corr.py
+++ b/vsg_core/analysis/audio_corr.py
@@ -558,6 +558,13 @@ def run_audio_correlation(
             'delay': int(round(raw_ms)), 'raw_delay': raw_ms,
             'match': match, 'start': t0, 'accepted': accepted
         })
+
+    # Release audio arrays immediately after correlation completes
+    ref_pcm = None
+    tgt_pcm = None
+    import gc
+    gc.collect()
+
     return results
 
 

--- a/vsg_qt/main_window/controller.py
+++ b/vsg_qt/main_window/controller.py
@@ -262,5 +262,10 @@ class MainController:
             self.append_log(f"[ERROR] Failed to archive logs: {e}")
 
     def on_close(self):
+        # Cancel any running worker to prevent signal crashes
+        if self.worker is not None:
+            self.worker.cancel()
+            self.append_log("[SHUTDOWN] Cancelling background tasks...")
+
         self.save_ui_to_config()
         self.layout_manager.cleanup_all()

--- a/vsg_qt/worker/runner.py
+++ b/vsg_qt/worker/runner.py
@@ -16,30 +16,85 @@ class JobWorker(QRunnable):
         self.and_merge = and_merge
         self.output_dir = output_dir
         self.signals = WorkerSignals()
+        self.cancelled = False
+
+    def _safe_log(self, msg: str):
+        """Safely emit log message, handling case where signals are deleted during GUI shutdown."""
+        try:
+            if hasattr(self, 'signals') and self.signals is not None:
+                self.signals.log.emit(msg)
+        except (RuntimeError, AttributeError):
+            # Signals deleted during GUI cleanup - silently ignore
+            pass
+
+    def _safe_progress(self, val: float):
+        """Safely emit progress update, handling case where signals are deleted during GUI shutdown."""
+        try:
+            if hasattr(self, 'signals') and self.signals is not None:
+                self.signals.progress.emit(val)
+        except (RuntimeError, AttributeError):
+            # Signals deleted during GUI cleanup - silently ignore
+            pass
+
+    def _safe_status(self, msg: str):
+        """Safely emit status update, handling case where signals are deleted during GUI shutdown."""
+        try:
+            if hasattr(self, 'signals') and self.signals is not None:
+                self.signals.status.emit(msg)
+        except (RuntimeError, AttributeError):
+            # Signals deleted during GUI cleanup - silently ignore
+            pass
+
+    def _safe_finished_job(self, result: Dict[str, Any]):
+        """Safely emit job finished signal, handling case where signals are deleted during GUI shutdown."""
+        try:
+            if hasattr(self, 'signals') and self.signals is not None:
+                self.signals.finished_job.emit(result)
+        except (RuntimeError, AttributeError):
+            # Signals deleted during GUI cleanup - silently ignore
+            pass
+
+    def _safe_finished_all(self, results: List[Dict[str, Any]]):
+        """Safely emit all jobs finished signal, handling case where signals are deleted during GUI shutdown."""
+        try:
+            if hasattr(self, 'signals') and self.signals is not None:
+                self.signals.finished_all.emit(results)
+        except (RuntimeError, AttributeError):
+            # Signals deleted during GUI cleanup - silently ignore
+            pass
+
+    def cancel(self):
+        """Request cancellation of this worker."""
+        self.cancelled = True
 
     @Slot()
     def run(self):
         pipeline = JobPipeline(
             config=self.config,
-            log_callback=lambda msg: self.signals.log.emit(msg),
-            progress_callback=lambda val: self.signals.progress.emit(val),
+            log_callback=self._safe_log,
+            progress_callback=self._safe_progress,
         )
 
         all_results: List[Dict[str, Any]] = []
         total_jobs = len(self.jobs)
 
         for i, job_data in enumerate(self.jobs, 1):
+            # Check for cancellation
+            if self.cancelled:
+                self._safe_log(f"[WORKER] Cancelled by user, stopping at job {i}/{total_jobs}")
+                break
+
             sources = job_data.get('sources', {})
             source1_file = sources.get("Source 1")
             if not source1_file:
-                self.signals.log.emit(f"[FATAL WORKER ERROR] Job {i} is missing 'Source 1'. Skipping.")
+                self._safe_log(f"[FATAL WORKER ERROR] Job {i} is missing 'Source 1'. Skipping.")
                 continue
 
             # Store original Source 1 path for batch output folder logic in controller
             job_data['ref_path_for_batch_check'] = source1_file
 
             try:
-                self.signals.status.emit(f'Processing {i}/{total_jobs}: {Path(source1_file).name}')
+                self._safe_status(f'Processing {i}/{total_jobs}: {Path(source1_file).name}')
 
                 result = pipeline.run_job(
                     sources=sources,
@@ -51,7 +106,7 @@ class JobWorker(QRunnable):
 
                 result['job_data_for_batch_check'] = job_data
 
-                self.signals.finished_job.emit(result)
+                self._safe_finished_job(result)
                 all_results.append(result)
 
             except Exception as e:
@@ -60,8 +115,8 @@ class JobWorker(QRunnable):
                     'name': Path(source1_file).name,
                     'job_data_for_batch_check': job_data
                 }
-                self.signals.log.emit(f'[FATAL WORKER ERROR] Job {i} failed: {e}')
-                self.signals.finished_job.emit(error_result)
+                self._safe_log(f'[FATAL WORKER ERROR] Job {i} failed: {e}')
+                self._safe_finished_job(error_result)
                 all_results.append(error_result)
 
-        self.signals.finished_all.emit(all_results)
+        self._safe_finished_all(all_results)


### PR DESCRIPTION
Fixes RuntimeError when background workers try to emit signals after GUI cleanup has started, causing a cascade of error-handling failures.

Root cause:
- Worker lambdas directly called self.signals.emit() methods
- When GUI closed, signals object was deleted first
- Background threads (source separation, QA checks) kept running
- Error handlers tried to log errors → crashed → more error handlers crashed → cascade failure loop

Changes:

1. Worker signal emission (vsg_qt/worker/runner.py):
   - Add safe wrapper methods (_safe_log, _safe_progress, etc.)
   - Check if signals exist before emitting
   - Catch RuntimeError/AttributeError silently
   - Add self.cancelled flag for graceful shutdown
   - Check cancellation flag between jobs

2. Worker cancellation on close (vsg_qt/main_window/controller.py):
   - Call worker.cancel() in on_close() if worker is running
   - Prevents new jobs from starting during shutdown

3. Audio memory cleanup (vsg_core/analysis/audio_corr.py):
   - Explicitly release ref_pcm and tgt_pcm arrays after correlation
   - Force garbage collection to free large numpy arrays immediately
   - Reduces memory usage between tasks

This ensures:
- No crashes when closing app during source separation
- Background tasks detect cancellation and stop gracefully
- Large audio buffers are released immediately after use
- Error handlers can safely log without crashing