### PR TITLE
Add final cleanup before Python shutdown to prevent nanobind leaks

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,7 +22,23 @@ def main():
     app.setApplicationName("Video Sync & Merge")
     window = MainWindow()
     window.show()
-    sys.exit(app.exec())
+
+    exit_code = app.exec()
+
+    # Final cleanup before Python shutdown to prevent nanobind leaks
+    # This runs after Qt cleanup but before Python's module teardown
+    try:
+        from vsg_core.subtitles.frame_utils import clear_vfr_cache
+        clear_vfr_cache()
+    except ImportError:
+        pass
+
+    # Force final garbage collection before exit
+    import gc
+    gc.collect()
+    gc.collect()  # Run twice for good measure
+
+    sys.exit(exit_code)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
The nanobind leak checker runs in an atexit handler after Python has started module teardown. Our cleanup was running during Qt's on_close() but that happens before Python's cleanup phase begins.

The timing issue:
1. User closes app → Qt on_close() runs → clear_vfr_cache() called
2. Qt exits → sys.exit(app.exec()) called
3. Python starts module teardown
4. nanobind's atexit handler runs → detects leaks

Solution:
- Capture exit code from app.exec()
- Call clear_vfr_cache() one final time AFTER Qt exits
- Call gc.collect() twice to ensure all circular refs are cleaned
- Then sys.exit() with the captured code

This ensures VideoTimestamps instances are fully released before nanobind's leak checker runs.