### PR TITLE
Fix settings not being passed to video-verified sync plugin

### DIFF
--- a/vsg_core/orchestrator/steps/subtitles_step.py
+++ b/vsg_core/orchestrator/steps/subtitles_step.py
@@ -856,7 +856,8 @@ class SubtitlesStep:
                 source_video=str(source_video) if source_video else None,
                 target_video=str(target_video) if target_video else None,
                 runner=runner,
-                config=ctx.settings.to_dict(),
+                settings=ctx.settings,  # Pass AppSettings directly for plugins that need it
+                config=ctx.settings.to_dict(),  # Keep dict for backward compatibility
                 temp_dir=ctx.temp_dir,
                 sync_exclusion_styles=getattr(item, "sync_exclusion_styles", None),
                 sync_exclusion_mode=getattr(item, "sync_exclusion_mode", "exclude"),

--- a/vsg_core/subtitles/data.py
+++ b/vsg_core/subtitles/data.py
@@ -1059,7 +1059,8 @@ class SubtitleData:
             source_video=source_video,
             target_video=target_video,
             runner=runner,
-            config=config or {},
+            settings=config,  # Pass as 'settings' for sync plugins that expect AppSettings
+            config=config or {},  # Keep for backward compatibility
             **kwargs,
         )
 


### PR DESCRIPTION
The plugin.apply() was passing config=dict but video_verified.py expected settings=AppSettings. Added settings=ctx.settings parameter so the plugin receives the AppSettings object directly.

This fixes the frame audit feature not triggering because settings was always None.

https://claude.ai/code/session_01NttAQXFxhGHxupJQoRJgwg